### PR TITLE
Allow reuse of a Redis ConnectionMultiplexer instance between RedisCache and RedisBackplane

### DIFF
--- a/src/ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis/RedisBackplaneOptions.cs
+++ b/src/ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis/RedisBackplaneOptions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Options;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
 namespace ZiggyCreatures.Caching.Fusion.Backplane.StackExchangeRedis;
@@ -19,6 +21,11 @@ public class RedisBackplaneOptions
 	/// This is preferred over Configuration.
 	/// </summary>
 	public ConfigurationOptions? ConfigurationOptions { get; set; }
+
+	/// <summary>
+	/// Gets or sets a delegate to create the ConnectionMultiplexer instance.
+	/// </summary>
+    public Func<Task<IConnectionMultiplexer>>? ConnectionMultiplexerFactory { get; set; }
 
 	/// <summary>
 	/// The configuration used to connect to Redis.

--- a/src/ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis/RedisBackplane_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis/RedisBackplane_Sync.cs
@@ -20,7 +20,10 @@ public partial class RedisBackplane
 			if (_connection is not null)
 				return;
 
-			_connection = ConnectionMultiplexer.Connect(GetConfigurationOptions());
+			_connection = _options.ConnectionMultiplexerFactory is null 
+				? ConnectionMultiplexer.Connect(GetConfigurationOptions())
+				: _options.ConnectionMultiplexerFactory().GetAwaiter().GetResult();
+			
 			if (_connection is not null)
 			{
 				_connection.ConnectionRestored += OnReconnect;

--- a/src/ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis/ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis.xml
+++ b/src/ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis/ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis.xml
@@ -44,6 +44,11 @@
             This is preferred over Configuration.
             </summary>
         </member>
+        <member name="P:ZiggyCreatures.Caching.Fusion.Backplane.StackExchangeRedis.RedisBackplaneOptions.ConnectionMultiplexerFactory">
+            <summary>
+            Gets or sets a delegate to create the ConnectionMultiplexer instance.
+            </summary>
+        </member>
         <member name="P:ZiggyCreatures.Caching.Fusion.Backplane.StackExchangeRedis.RedisBackplaneOptions.VerifyReceivedClientsCountAfterPublish">
             <summary>
             The configuration used to connect to Redis.


### PR DESCRIPTION
Added a factory method (ConnectionMultiplexerFactory) to RedisBackplaneOptions similar to that found in Microsoft.Extensions.Caching.Redis.RedisCacheOptions. This will allow for the shared use of a ConnectionMultiplexer between a RedisCache and RedisBackplane.

```csharp
var options = ConfigurationOptions.Parse("REDIS_CONNECTION_STRING");
var multiplexer = ConnectionMultiplexer.Connect(options);

var redisCache = new RedisCache(new RedisCacheOptions() { 
    ConnectionMultiplexerFactory = async () => await Task.FromResult((IConnectionMultiplexer)multiplexer).ConfigureAwait(false) });

var redisBackplane = new RedisBackplane(new RedisBackplaneOptions() { 
    ConnectionMultiplexerFactory = async () => await Task.FromResult((IConnectionMultiplexer)multiplexer).ConfigureAwait(false) });

builder.Services.AddFusionCache()
    .WithDistributedCache(redisCache)
    .WithBackplane(redisBackplane);
```