### PR TITLE
Value FailSafeMaxDuration of log message for IncoherentOptionsNormali…

### DIFF
--- a/src/ZiggyCreatures.FusionCache/FusionCacheEntryOptions.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheEntryOptions.cs
@@ -660,7 +660,7 @@ public sealed class FusionCacheEntryOptions
 		if (incoherentFailSafeMaxDuration)
 		{
 			if (logger?.IsEnabled(options.IncoherentOptionsNormalizationLogLevel) ?? false)
-				logger.Log(options.IncoherentOptionsNormalizationLogLevel, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): FailSafeMaxDuration {{FailSafeMaxDuration}} was lower than the Duration {Duration} on {Options} {MemoryOptions}. Duration has been used instead.", options.CacheName, options.InstanceId, operationId, key, FailSafeMaxDuration.ToLogString(), Duration.ToLogString(), this.ToLogString(), res.ToLogString());
+				logger.Log(options.IncoherentOptionsNormalizationLogLevel, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): FailSafeMaxDuration {FailSafeMaxDuration} was lower than the Duration {Duration} on {Options} {MemoryOptions}. Duration has been used instead.", options.CacheName, options.InstanceId, operationId, key, FailSafeMaxDuration.ToLogString(), Duration.ToLogString(), this.ToLogString(), res.ToLogString());
 		}
 
 		return res;


### PR DESCRIPTION
…zationLogLevel fixed

Value FailSafeMaxDuration of log message for IncoherentOptionsNormalizationLogLevel fixed (FailsafeMaxDuration should be logged instead of static text {FailSafeMaxDuration})