### PR TITLE
Add the evict reason as a metric tag so we can categorize the evict reason.

### DIFF
--- a/src/ZiggyCreatures.FusionCache/Events/FusionCacheMemoryEventsHub.cs
+++ b/src/ZiggyCreatures.FusionCache/Events/FusionCacheMemoryEventsHub.cs
@@ -45,7 +45,7 @@ public sealed class FusionCacheMemoryEventsHub
 
 	internal void OnEviction(string operationId, string key, EvictionReason reason, object? value)
 	{
-		Metrics.CounterMemoryEvict.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId, new KeyValuePair<string, object?>("fusioncache.evict.reason", reason.ToString()));
+		Metrics.CounterMemoryEvict.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId, new KeyValuePair<string, object?>("fusioncache.memory.evict_reason", reason.ToString()));
 
 		Eviction?.SafeExecute(operationId, key, _cache, () => new FusionCacheEntryEvictionEventArgs(key, reason, value), nameof(Eviction), _logger, _errorsLogLevel, _syncExecution);
 	}

--- a/src/ZiggyCreatures.FusionCache/Events/FusionCacheMemoryEventsHub.cs
+++ b/src/ZiggyCreatures.FusionCache/Events/FusionCacheMemoryEventsHub.cs
@@ -45,7 +45,7 @@ public sealed class FusionCacheMemoryEventsHub
 
 	internal void OnEviction(string operationId, string key, EvictionReason reason, object? value)
 	{
-		Metrics.CounterMemoryEvict.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId);
+		Metrics.CounterMemoryEvict.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId, new KeyValuePair<string, object?>("fusioncache.evict.reason", reason.ToString()));
 
 		Eviction?.SafeExecute(operationId, key, _cache, () => new FusionCacheEntryEvictionEventArgs(key, reason, value), nameof(Eviction), _logger, _errorsLogLevel, _syncExecution);
 	}


### PR DESCRIPTION
I mentioned adding the reason tag in the [OpenTelemetry support discussion](https://github.com/ZiggyCreatures/FusionCache/issues/187#issuecomment-1913647998).  It may have gotten lost in the naming discussion that took over my comment.

Seems like a reasonable addition.  What do you think?  I used it in my plugin and in many working code deployments.

Thank you.

- Joe


