### PR TITLE
#230 Add in suppression of TFM Warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,7 @@
 		<Nullable>enable</Nullable>
 		<PackageIcon>logo-128x128.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Enabled suppression of TFM Build warnings.

Closes #230 