### PR TITLE
Fix SerializationTests on Linux and macOS

### DIFF
--- a/tests/SerializerPayloadGenerator/Program.cs
+++ b/tests/SerializerPayloadGenerator/Program.cs
@@ -40,7 +40,7 @@ static void TestSamples<T>(IFusionCacheSerializer[] serializers)
 
 		var filePrefix = $"{serializer.GetType().Name}__";
 
-		var files = Directory.GetFiles("samples\\", filePrefix + "*.bin");
+		var files = Directory.GetFiles("Samples", filePrefix + "*.bin");
 
 		Console.WriteLine($"SERIALIZER: {serializer.GetType().Name} v{version ?? "?"}");
 		Console.WriteLine("SAMPLES:");

--- a/tests/ZiggyCreatures.FusionCache.Tests/SerializationTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/SerializationTests.cs
@@ -233,7 +233,7 @@ public class SerializationTests
 
 		var filePrefix = $"{serializer.GetType().Name}__";
 
-		var files = Directory.GetFiles("Samples\\", filePrefix + "*.bin");
+		var files = Directory.GetFiles("Samples", filePrefix + "*.bin");
 
 		TestOutput.WriteLine($"Found {files.Length} samples for {serializer.GetType().Name}");
 
@@ -261,7 +261,7 @@ public class SerializationTests
 
 		var filePrefix = $"{serializer.GetType().Name}__";
 
-		var files = Directory.GetFiles("Samples\\", filePrefix + "*.bin");
+		var files = Directory.GetFiles("Samples", filePrefix + "*.bin");
 
 		TestOutput.WriteLine($"Found {files.Length} samples for {serializer.GetType().Name}");
 


### PR DESCRIPTION
It would fail with `System.IO.DirectoryNotFoundException`
> Could not find a part of the path '[…]/FusionCache/tests/ZiggyCreatures.FusionCache.Tests/bin/Debug/net8.0/Samples\\'.