### PR TITLE
Add a CacheNames property to IFusionCacheProvider

### DIFF
--- a/src/ZiggyCreatures.FusionCache/IFusionCacheProvider.cs
+++ b/src/ZiggyCreatures.FusionCache/IFusionCacheProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace ZiggyCreatures.Caching.Fusion;
+﻿using System.Collections.Generic;
+
+namespace ZiggyCreatures.Caching.Fusion;
 
 /// <summary>
 /// The provider to work with multiple named FusionCache instances, kinda like Microsoft's HTTP named clients (see https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests#named-clients)
@@ -18,4 +20,9 @@ public interface IFusionCacheProvider
 	/// <param name="cacheName">The name of the cache: it must match the one provided during registration.</param>
 	/// <returns>The FusionCache instance corresponding to the cache name specified.</returns>
 	IFusionCache? GetCacheOrNull(string cacheName);
+
+	/// <summary>
+	/// The collection of all available FusionCache names.
+	/// </summary>
+	IReadOnlyCollection<string> CacheNames { get; }
 }

--- a/src/ZiggyCreatures.FusionCache/Internals/Provider/FusionCacheProvider.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Provider/FusionCacheProvider.cs
@@ -59,4 +59,6 @@ internal sealed class FusionCacheProvider
 			: $"No cache has been registered with name ({cacheName}): make sure you registered it with the AddFusionCache(\"{cacheName}\") method."
 		);
 	}
+
+	public IReadOnlyCollection<string> CacheNames => _lazyNamedCaches.Select(e => e.CacheName).ToList();
 }


### PR DESCRIPTION
Note: this pull request has been opened as draft mainly to discuss the matter since adding an interface member is a breaking change.

I have a scenario in my mind where I'd like to be able to configure the `DefaultEntryOptions` after the caches are created. I can keep track of all the cache names in a separate collection but I think it would be a good idea to consider this for version 2.0 since the `IFusionCacheProvider` is the _natural_ place to get all the configured cache names. And I can't inject `IEnumerable<LazyNamedCache>` to retrieve all the names since `LazyNamedCache` is an internal type.

Also, the implementation is not very efficient but it was written so in order to minimize conflicts with #249. And after #249 is merged the implementation would become `public IReadOnlyCollection<string> CacheNames => _caches.Keys;`