### PR TITLE
Adaptive Options Should Be Evaluated On Error

### DIFF
--- a/src/ZiggyCreatures.FusionCache/FusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache.cs
@@ -913,7 +913,6 @@ public partial class FusionCache
 		{
 			options = maybeNewOptions;
 
-			// i'm not sure why we were updating these values before - they are not used after adaptive options are updated
 			dca = GetCurrentDistributedAccessor(options);
 			mca = GetCurrentMemoryAccessor(options);
 		}

--- a/src/ZiggyCreatures.FusionCache/FusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache.cs
@@ -904,4 +904,18 @@ public partial class FusionCache
 			return (true, false, false);
 		}
 	}
+
+	private void UpdateAdaptiveOptions<TValue>(FusionCacheFactoryExecutionContext<TValue> ctx, ref FusionCacheEntryOptions options, ref DistributedCacheAccessor? dca, ref MemoryCacheAccessor? mca)
+	{
+		// UPDATE ADAPTIVE OPTIONS
+		var maybeNewOptions = ctx.GetOptions();
+		if (ReferenceEquals(options, maybeNewOptions) == false)
+		{
+			options = maybeNewOptions;
+
+			// i'm not sure why we were updating these values before - they are not used after adaptive options are updated
+			dca = GetCurrentDistributedAccessor(options);
+			mca = GetCurrentMemoryAccessor(options);
+		}
+	}
 }

--- a/src/ZiggyCreatures.FusionCache/FusionCache_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache_Async.cs
@@ -164,15 +164,7 @@ public partial class FusionCache
 
 						hasNewValue = true;
 
-						// UPDATE ADAPTIVE OPTIONS
-						var maybeNewOptions = ctx.GetOptions();
-						if (ReferenceEquals(options, maybeNewOptions) == false)
-						{
-							options = maybeNewOptions;
-
-							dca = GetCurrentDistributedAccessor(options);
-							mca = GetCurrentMemoryAccessor(options);
-						}
+						UpdateAdaptiveOptions(ctx, ref options, ref dca, ref mca);
 
 						entry = FusionCacheMemoryEntry<TValue>.CreateFromOptions(value, options, isStale, ctx.LastModified, ctx.ETag, null);
 
@@ -189,6 +181,8 @@ public partial class FusionCache
 					}
 					catch (Exception exc)
 					{
+						UpdateAdaptiveOptions(ctx, ref options, ref dca, ref mca);
+
 						ProcessFactoryError(operationId, key, exc);
 
 						MaybeBackgroundCompleteTimedOutFactory<TValue>(operationId, key, ctx, factoryTask, options, activityForFactory);

--- a/src/ZiggyCreatures.FusionCache/FusionCache_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache_Sync.cs
@@ -164,15 +164,7 @@ public partial class FusionCache
 
 						hasNewValue = true;
 
-						// UPDATE ADAPTIVE OPTIONS
-						var maybeNewOptions = ctx.GetOptions();
-						if (ReferenceEquals(options, maybeNewOptions) == false)
-						{
-							options = maybeNewOptions;
-
-							dca = GetCurrentDistributedAccessor(options);
-							mca = GetCurrentMemoryAccessor(options);
-						}
+						UpdateAdaptiveOptions(ctx, ref options, ref dca, ref mca);
 
 						entry = FusionCacheMemoryEntry<TValue>.CreateFromOptions(value, options, isStale, ctx.LastModified, ctx.ETag, null);
 
@@ -189,6 +181,8 @@ public partial class FusionCache
 					}
 					catch (Exception exc)
 					{
+						UpdateAdaptiveOptions(ctx, ref options, ref dca, ref mca);
+
 						ProcessFactoryError(operationId, key, exc);
 
 						MaybeBackgroundCompleteTimedOutFactory<TValue>(operationId, key, ctx, factoryTask, options, activityForFactory);

--- a/tests/ZiggyCreatures.FusionCache.Tests/FailSafeTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/FailSafeTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace FusionCacheTests;
+
+public class FailSafeTests
+{
+	private readonly FusionCache _cache;
+	private readonly string _key;
+
+	public FailSafeTests()
+	{
+		var options = new FusionCacheOptions();
+
+		options.DefaultEntryOptions.Duration = TimeSpan.FromMinutes(5);
+		options.DefaultEntryOptions.IsFailSafeEnabled = true; // enable by default
+
+		_cache = new FusionCache(options);
+		_key = "foo";
+
+		_cache.GetOrSet(_key, "bar"); // init the key
+
+		_cache.Expire(_key); // logically expire the key so the fail safe logic triggers.
+	}
+
+	[Fact]
+	public async Task FailSafe_CanBeDisabled_OnFactoryFailureAsync()
+	{
+		await Assert.ThrowsAsync<Exception>(async () =>
+		{
+			await _cache.GetOrSetAsync<string>(_key, (ctx, ct) =>
+			{
+				try
+				{
+					throw new Exception("Factory failed");
+				}
+				finally
+				{
+					ctx.Options.SetFailSafe(false); // disable fail safe.
+				}
+			});
+		});
+	}
+
+	[Fact]
+	public async Task FailSafe_CanBeDisabled_OnFactoryFailure()
+	{
+		Assert.Throws<Exception>(() =>
+		{
+			_cache.GetOrSet<string>(_key, (ctx, ct) =>
+			{
+				try
+				{
+					throw new Exception("Factory failed");
+				}
+				finally
+				{
+					ctx.Options.SetFailSafe(false); // disable fail safe.
+				}
+			});
+		});
+	}
+}
+


### PR DESCRIPTION
Adaptive Options are now being respected before executing failsafe logic to allow for dynamic fail-safe enablement based on exception type.

First commit illustrates the problem (red)
Second commit illustrates the solution (green)

I ran all tests in the solution locally (a couple flaked out and succeeded on re-run 🤷 )

![image](https://github.com/user-attachments/assets/2ed639cc-0765-491f-bdd4-37a3b93bcacb)


Please let me know if there's anything you would like me to change - took the liberty of making the adaptive options code sharable to not introduce 4x duplication (vs 2 previously).