### PR TITLE
Add PostConfigure for CacheKeyPrefix ':' postfix

### DIFF
--- a/src/ZiggyCreatures.FusionCache/FusionCacheBuilderExtMethods.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheBuilderExtMethods.cs
@@ -89,7 +89,7 @@ public static partial class FusionCacheBuilderExtMethods
 	/// <returns>The <see cref="IFusionCacheBuilder"/> so that additional calls can be chained.</returns>
 	public static IFusionCacheBuilder WithCacheKeyPrefix(this IFusionCacheBuilder builder)
 	{
-		return builder.WithCacheKeyPrefix(builder.CacheName + ":");
+		return builder.WithCacheKeyPrefix(builder.CacheName);
 	}
 
 	/// <summary>

--- a/src/ZiggyCreatures.FusionCache/FusionCacheServiceCollectionExtensions.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheServiceCollectionExtensions.cs
@@ -139,12 +139,18 @@ public static class FusionCacheServiceCollectionExtensions
 		if (cacheName is null)
 			throw new ArgumentNullException(nameof(cacheName));
 
-		services.AddOptions();
-
-		services.Configure<FusionCacheOptions>(cacheName, opt =>
-		{
-			opt.CacheName = cacheName;
-		});
+		services.AddOptions<FusionCacheOptions>(cacheName)
+			.Configure(opt =>
+			{
+				opt.CacheName = cacheName;
+			})
+			.PostConfigure(opt =>
+			{
+				if (opt.CacheKeyPrefix is not null && !opt.CacheKeyPrefix.EndsWith(":"))
+				{
+					opt.CacheKeyPrefix += ":";
+				}
+			});
 
 		services.AddFusionCacheProvider();
 


### PR DESCRIPTION
This is done to emulate the postfix behaviour from `IFusionCacheBuilder.WithCacheKeyPrefix` when configuring FusionCacheOptions via `IServiceCollection.Configure<FusionCacheOptions>(Action<FusionCache>)`.