### PR TITLE
Adjust HybridCache dependency

### DIFF
--- a/src/ZiggyCreatures.FusionCache.MicrosoftHybridCache/ZiggyCreatures.FusionCache.MicrosoftHybridCache.csproj
+++ b/src/ZiggyCreatures.FusionCache.MicrosoftHybridCache/ZiggyCreatures.FusionCache.MicrosoftHybridCache.csproj
@@ -19,7 +19,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.0.0-preview.9.24556.5" />
+	  <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ZiggyCreatures.FusionCache.MicrosoftHybridCache/ZiggyCreatures.FusionCache.MicrosoftHybridCache.csproj
+++ b/src/ZiggyCreatures.FusionCache.MicrosoftHybridCache/ZiggyCreatures.FusionCache.MicrosoftHybridCache.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Version>2.0.0-preview-3</Version>
 		<PackageId>ZiggyCreatures.FusionCache.MicrosoftHybridCache</PackageId>
-		<Description>An implementation of Microsoft's HybridCache based on FusionCache, for when you need to depend of the Microsoft abstraction, but want the power of FusionCache</Description>
+		<Description>An implementation of Microsoft's HybridCache based on FusionCache, for when you need to depend on the Microsoft abstraction, but want the power of FusionCache</Description>
 		<PackageTags>caching;cache;hybrid;hybrid-cache;hybridcache;multi-level;multilevel;fusion;fusioncache;fusion-cache;performance;async;ziggy</PackageTags>
 		<RootNamespace>ZiggyCreatures.Caching.Fusion.MicrosoftHybridCache</RootNamespace>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/ZiggyCreatures.FusionCache.MicrosoftHybridCache/docs/README.md
+++ b/src/ZiggyCreatures.FusionCache.MicrosoftHybridCache/docs/README.md
@@ -10,4 +10,4 @@ Find out [more](https://github.com/ZiggyCreatures/FusionCache).
 
 ## 📦 This package
 
-This package is an implementation of Microsoft's HybridCache based on FusionCache, for when you need to depend of the Microsoft abstraction, but want the power of FusionCache.
+This package is an implementation of Microsoft's HybridCache based on FusionCache, for when you need to depend on the Microsoft abstraction, but want the power of FusionCache.


### PR DESCRIPTION
I was in the process of replacing the pre-release HybridCache implementation with [FusionCache's preview ZiggyCreatures.FusionCache.MicrosoftHybridCache package](https://www.nuget.org/packages/ZiggyCreatures.FusionCache.MicrosoftHybridCache/2.0.0-preview-3) and noticed that there were still references to [the Microsoft.Extensions.Caching.Hybrid package](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Hybrid/9.0.0-preview.9.24556.5) in my `packages.lock.json` files. After adjusting FusionCache's reference, it still builds without issue, so I thought it made sense to only reference the `HybridCache` abstract base class from [the stable Microsoft.Extensions.Caching.Abstractions 9.0.0 package](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Abstractions/9.0.0).

Hope it helps!