### PR TITLE
Removing the dependency on Microsoft.IO.RecyclableStream and improving serializer performance

### DIFF
--- a/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SerializersBenchmark.cs
+++ b/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SerializersBenchmark.cs
@@ -11,8 +11,6 @@ using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using MemoryPack;
 using MessagePack;
-using Microsoft.IO;
-
 using ZiggyCreatures.Caching.Fusion.Serialization;
 using ZiggyCreatures.Caching.Fusion.Serialization.CysharpMemoryPack;
 using ZiggyCreatures.Caching.Fusion.Serialization.NeueccMessagePack;

--- a/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SerializersBenchmark.cs
+++ b/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SerializersBenchmark.cs
@@ -12,6 +12,7 @@ using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using MemoryPack;
 using MessagePack;
 using Microsoft.IO;
+
 using ZiggyCreatures.Caching.Fusion.Serialization;
 using ZiggyCreatures.Caching.Fusion.Serialization.CysharpMemoryPack;
 using ZiggyCreatures.Caching.Fusion.Serialization.NeueccMessagePack;

--- a/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SerializersBenchmark.cs
+++ b/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SerializersBenchmark.cs
@@ -121,19 +121,7 @@ public class SerializersBenchmark
 		yield return new FusionCacheNeueccMessagePackSerializer();
 		yield return new FusionCacheNewtonsoftJsonSerializer();
 		yield return new FusionCacheProtoBufNetSerializer();
-		yield return new FusionCacheProtoBufNetSerializer(new FusionCacheProtoBufNetSerializer.Options
-		{
-			StreamManager = new RecyclableMemoryStreamManager()
-		});
 		yield return new FusionCacheServiceStackJsonSerializer();
-		yield return new FusionCacheServiceStackJsonSerializer(new FusionCacheServiceStackJsonSerializer.Options
-		{
-			StreamManager = new RecyclableMemoryStreamManager()
-		});
 		yield return new FusionCacheSystemTextJsonSerializer();
-		yield return new FusionCacheSystemTextJsonSerializer(new FusionCacheSystemTextJsonSerializer.Options
-		{
-			StreamManager = new RecyclableMemoryStreamManager()
-		});
 	}
 }

--- a/src/ZiggyCreatures.FusionCache.Serialization.CysharpMemoryPack/FusionCacheCysharpMemoryPackSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.CysharpMemoryPack/FusionCacheCysharpMemoryPackSerializer.cs
@@ -56,7 +56,7 @@ public class FusionCacheCysharpMemoryPackSerializer
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public byte[] Serialize<T>(T? obj)
 	{
-		var buffer = ArrayPoolBufferWriter.Rent();
+		var buffer = new ArrayPoolBufferWriter();
 		MemoryPackWriter<ArrayPoolBufferWriter> writer = new(ref buffer, MemoryPackWriterOptionalStatePool.Rent(_serializerOptions));
 		try
 		{
@@ -65,7 +65,7 @@ public class FusionCacheCysharpMemoryPackSerializer
 		}
 		finally
 		{
-			ArrayPoolBufferWriter.Return(buffer);
+			buffer.Dispose();
 		}
 	}
 

--- a/src/ZiggyCreatures.FusionCache.Serialization.CysharpMemoryPack/FusionCacheCysharpMemoryPackSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.CysharpMemoryPack/FusionCacheCysharpMemoryPackSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using MemoryPack;
 using ZiggyCreatures.Caching.Fusion.Internals;
@@ -52,24 +53,38 @@ public class FusionCacheCysharpMemoryPackSerializer
 	private readonly MemoryPackSerializerOptions? _serializerOptions;
 
 	/// <inheritdoc />
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public byte[] Serialize<T>(T? obj)
 	{
-		return MemoryPackSerializer.Serialize<T>(obj, _serializerOptions);
+		var buffer = ArrayPoolBufferWriter.Rent();
+		MemoryPackWriter<ArrayPoolBufferWriter> writer = new(ref buffer, MemoryPackWriterOptionalStatePool.Rent(_serializerOptions));
+		try
+		{
+			MemoryPackSerializer.Serialize(ref writer, obj);
+			return buffer.ToArray();
+		}
+		finally
+		{
+			ArrayPoolBufferWriter.Return(buffer);
+		}
 	}
 
 	/// <inheritdoc />
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public T? Deserialize<T>(byte[] data)
 	{
 		return MemoryPackSerializer.Deserialize<T?>(data, _serializerOptions);
 	}
 
 	/// <inheritdoc />
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public ValueTask<byte[]> SerializeAsync<T>(T? obj, CancellationToken token = default)
 	{
 		return new ValueTask<byte[]>(Serialize(obj));
 	}
 
 	/// <inheritdoc />
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public ValueTask<T?> DeserializeAsync<T>(byte[] data, CancellationToken token = default)
 	{
 		return new ValueTask<T?>(Deserialize<T>(data));

--- a/src/ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack/FusionCacheNeueccMessagePackSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack/FusionCacheNeueccMessagePackSerializer.cs
@@ -53,17 +53,9 @@ public class FusionCacheNeueccMessagePackSerializer
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public byte[] Serialize<T>(T? obj)
 	{
-		var writer = ArrayPoolBufferWriter.Rent();
-
-		try
-		{
-			MessagePackSerializer.Serialize(writer, obj, _serializerOptions);
-			return writer.ToArray();
-		}
-		finally
-		{
-			ArrayPoolBufferWriter.Return(writer);
-		}
+		using var writer = new ArrayPoolBufferWriter();
+		MessagePackSerializer.Serialize(writer, obj, _serializerOptions);
+		return writer.ToArray();
 	}
 
 	/// <inheritdoc />

--- a/src/ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack/FusionCacheNeueccMessagePackSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack/FusionCacheNeueccMessagePackSerializer.cs
@@ -1,7 +1,12 @@
-﻿using System.Threading;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using MessagePack;
 using MessagePack.Resolvers;
+
+using ZiggyCreatures.Caching.Fusion.Internals;
 
 namespace ZiggyCreatures.Caching.Fusion.Serialization.NeueccMessagePack;
 
@@ -11,7 +16,7 @@ namespace ZiggyCreatures.Caching.Fusion.Serialization.NeueccMessagePack;
 public class FusionCacheNeueccMessagePackSerializer
 	: IFusionCacheSerializer
 {
-	/// <summary>
+/// <summary>
 	/// The options class for the <see cref="FusionCacheNeueccMessagePackSerializer"/> class.
 	/// </summary>
 	public class Options
@@ -45,18 +50,31 @@ public class FusionCacheNeueccMessagePackSerializer
 	private readonly MessagePackSerializerOptions? _serializerOptions;
 
 	/// <inheritdoc />
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public byte[] Serialize<T>(T? obj)
 	{
-		return MessagePackSerializer.Serialize<T?>(obj, _serializerOptions);
+		var writer = ArrayPoolBufferWriter.Rent();
+
+		try
+		{
+			MessagePackSerializer.Serialize(writer, obj, _serializerOptions);
+			return writer.ToArray();
+		}
+		finally
+		{
+			ArrayPoolBufferWriter.Return(writer);
+		}
 	}
 
 	/// <inheritdoc />
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public T? Deserialize<T>(byte[] data)
 	{
-		return MessagePackSerializer.Deserialize<T?>(data, _serializerOptions);
+		return MessagePackSerializer.Deserialize<T?>(data.AsMemory(), _serializerOptions);
 	}
 
 	/// <inheritdoc />
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public ValueTask<byte[]> SerializeAsync<T>(T? obj, CancellationToken token = default)
 	{
 		// PER @neuecc 'S SUGGESTION: AVOID AWAITING ON A MEMORY STREAM
@@ -64,6 +82,7 @@ public class FusionCacheNeueccMessagePackSerializer
 	}
 
 	/// <inheritdoc />
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public ValueTask<T?> DeserializeAsync<T>(byte[] data, CancellationToken token = default)
 	{
 		// PER @neuecc 'S SUGGESTION: AVOID AWAITING ON A MEMORY STREAM

--- a/src/ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson/FusionCacheNewtonsoftJsonSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson/FusionCacheNewtonsoftJsonSerializer.cs
@@ -1,9 +1,20 @@
-﻿using System.Text;
+﻿using System.Buffers;
+using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
+using ZiggyCreatures.Caching.Fusion.Internals;
+
 namespace ZiggyCreatures.Caching.Fusion.Serialization.NewtonsoftJson;
+
+internal class JsonArrayPool : IArrayPool<char>
+{
+	internal static JsonArrayPool Shared { get; } = new JsonArrayPool();
+	public char[] Rent(int minimumLength) => ArrayPool<char>.Shared.Rent(minimumLength);
+	public void Return(char[]? array) => ArrayPool<char>.Shared.Return(array);
+}
 
 /// <summary>
 /// An implementation of <see cref="IFusionCacheSerializer"/> which uses the Newtonsoft Json.NET serializer.
@@ -11,6 +22,7 @@ namespace ZiggyCreatures.Caching.Fusion.Serialization.NewtonsoftJson;
 public class FusionCacheNewtonsoftJsonSerializer
 	: IFusionCacheSerializer
 {
+	private readonly JsonSerializer _jsonSerializer;
 	/// <summary>
 	/// The options class for the <see cref="FusionCacheNewtonsoftJsonSerializer"/> class.
 	/// </summary>
@@ -31,6 +43,7 @@ public class FusionCacheNewtonsoftJsonSerializer
 	public FusionCacheNewtonsoftJsonSerializer(JsonSerializerSettings? settings = null)
 	{
 		_serializerSettings = settings;
+		_jsonSerializer = JsonSerializer.Create(settings);
 	}
 
 	/// <summary>
@@ -48,13 +61,23 @@ public class FusionCacheNewtonsoftJsonSerializer
 	/// <inheritdoc />
 	public byte[] Serialize<T>(T? obj)
 	{
-		return _encoding.GetBytes(JsonConvert.SerializeObject(obj, _serializerSettings));
+		using var stream = new ArrayPoolWritableStream();
+		using var writer = new StreamWriter(stream);
+		using JsonTextWriter jsonWriter = new JsonTextWriter(writer);
+		jsonWriter.ArrayPool = JsonArrayPool.Shared;
+		_jsonSerializer.Serialize(jsonWriter, obj);
+		jsonWriter.Flush();
+		return stream.GetBytes();
 	}
 
 	/// <inheritdoc />
 	public T? Deserialize<T>(byte[] data)
 	{
-		return JsonConvert.DeserializeObject<T>(_encoding.GetString(data), _serializerSettings);
+		using var stream = new MemoryStream(data);
+		using var reader = new StreamReader(stream, _encoding);
+		using var jsonReader = new JsonTextReader(reader);
+		jsonReader.ArrayPool = JsonArrayPool.Shared;
+		return _jsonSerializer.Deserialize<T>(jsonReader);
 	}
 
 	/// <inheritdoc />

--- a/src/ZiggyCreatures.FusionCache.Serialization.ProtoBufNet/FusionCacheProtoBufNetSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.ProtoBufNet/FusionCacheProtoBufNetSerializer.cs
@@ -135,5 +135,5 @@ public class FusionCacheProtoBufNetSerializer
 	}
 
 	/// <inheritdoc />
-	public override string ToString() => $"{(_streamManager != null ? "Recyclable" : "")}{GetType().Name}";
+	public override string ToString() => GetType().Name;
 }

--- a/src/ZiggyCreatures.FusionCache.Serialization.ProtoBufNet/FusionCacheProtoBufNetSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.ProtoBufNet/FusionCacheProtoBufNetSerializer.cs
@@ -2,9 +2,12 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.IO;
+
+using ProtoBuf;
 using ProtoBuf.Meta;
 using ZiggyCreatures.Caching.Fusion.Internals;
 using ZiggyCreatures.Caching.Fusion.Internals.Distributed;
@@ -27,11 +30,6 @@ public class FusionCacheProtoBufNetSerializer
 		/// The optional <see cref="RuntimeTypeModel"/> object to use.
 		/// </summary>
 		public RuntimeTypeModel? Model { get; set; }
-
-		/// <summary>
-		/// The optional <see cref="RecyclableMemoryStreamManager"/> object to use.
-		/// </summary>
-		public RecyclableMemoryStreamManager? StreamManager { get; set; }
 	}
 
 	/// <summary>
@@ -41,85 +39,42 @@ public class FusionCacheProtoBufNetSerializer
 	public FusionCacheProtoBufNetSerializer(RuntimeTypeModel? model = null)
 	{
 		_model = model ?? RuntimeTypeModel.Default;
-
-		RegisterMetadataModel();
+		_modelsCache.GetOrAdd(_model, static (model) =>
+		{
+			lock (model)
+			{
+				model.Add(typeof(FusionCacheEntryMetadata), false).SetSurrogate(typeof(FusionCacheEntryMetadataSurrogate));
+				return [_metadataType];
+			}
+		});
 	}
 
 	/// <summary>
 	/// Create a new instance of a <see cref="FusionCacheProtoBufNetSerializer"/> object.
 	/// </summary>
 	/// <param name="options">The optional <see cref="Options"/> object to use.</param>
-	public FusionCacheProtoBufNetSerializer(Options? options)
-		: this(options?.Model)
+	public FusionCacheProtoBufNetSerializer(Options options)
+		: this(options.Model)
 	{
-		_streamManager = options?.StreamManager;
 	}
 
 	private static readonly ConcurrentDictionary<RuntimeTypeModel, HashSet<Type>> _modelsCache = [];
+	private static readonly ConcurrentDictionary<Type, bool> _suitableTypeCache = [];
 	private static readonly Type _metadataType = typeof(FusionCacheEntryMetadata);
 	private static readonly Type _distributedEntryOpenGenericType = typeof(FusionCacheDistributedEntry<>);
-
 	private readonly RuntimeTypeModel _model;
-	private readonly RecyclableMemoryStreamManager? _streamManager;
 
-	private MemoryStream GetMemoryStream()
-	{
-		return _streamManager?.GetStream() ?? new MemoryStream();
-	}
-
-	private MemoryStream GetMemoryStream(byte[] buffer)
-	{
-		return _streamManager?.GetStream(buffer) ?? new MemoryStream(buffer);
-	}
-
-	private void RegisterMetadataModel()
-	{
-		if (_modelsCache.TryGetValue(_model, out var tmp) == false)
-		{
-			lock (_modelsCache)
-			{
-				tmp = _modelsCache.GetOrAdd(_model, _ => []);
-			}
-		}
-
-		// ENSURE MODEL REGISTRATION FOR FusionCacheEntryMetadata
-		if (tmp.Contains(_metadataType))
-			return;
-
-		lock (tmp)
-		{
-			if (tmp.Contains(_metadataType))
-				return;
-
-			try
-			{
-				_model.Add(typeof(FusionCacheEntryMetadata), false)
-					.SetSurrogate(typeof(FusionCacheEntryMetadataSurrogate))
-				;
-
-				tmp.Add(_metadataType);
-			}
-			catch
-			{
-				// EMPTY
-			}
-		}
-	}
-
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private void MaybeRegisterDistributedEntryModel<T>()
 	{
 		var t = typeof(T);
 
-		if (t.IsGenericType == false || t.GetGenericTypeDefinition() != _distributedEntryOpenGenericType)
+		var isSuitableType = _suitableTypeCache.GetOrAdd(t, static (type) => type.IsGenericType && type.GetGenericTypeDefinition() == _distributedEntryOpenGenericType);
+
+		if (!isSuitableType)
 			return;
 
-		if (_modelsCache.TryGetValue(_model, out var tmp) == false)
-		{
-			lock (_modelsCache)
-			{
-				tmp = _modelsCache.GetOrAdd(_model, _ => []);
-			}
-		}
+		var tmp = _modelsCache[_model];
 
 		// ENSURE MODEL REGISTRATION FOR FusionCacheDistributedEntry<T>
 		if (tmp.Contains(t))
@@ -127,9 +82,6 @@ public class FusionCacheProtoBufNetSerializer
 
 		lock (tmp)
 		{
-			if (tmp.Contains(t))
-				return;
-
 			try
 			{
 				// NOTE: USING FusionCacheDistributedEntry<bool> HERE SINCE IT WILL
@@ -154,11 +106,9 @@ public class FusionCacheProtoBufNetSerializer
 	public byte[] Serialize<T>(T? obj)
 	{
 		MaybeRegisterDistributedEntryModel<T>();
-
-		using var stream = GetMemoryStream();
-
+		using var stream = new ArrayPoolWritableStream();
 		_model.Serialize(stream, obj);
-		return stream.ToArray();
+		return stream.GetBytes();
 	}
 
 	/// <inheritdoc />
@@ -169,9 +119,7 @@ public class FusionCacheProtoBufNetSerializer
 
 		MaybeRegisterDistributedEntryModel<T>();
 
-		using var stream = GetMemoryStream(data);
-
-		return _model.Deserialize<T?>(stream);
+		return _model.Deserialize<T?>((ReadOnlySpan<byte>)data);
 	}
 
 	/// <inheritdoc />

--- a/src/ZiggyCreatures.FusionCache.Serialization.ProtoBufNet/ZiggyCreatures.FusionCache.Serialization.ProtoBufNet.csproj
+++ b/src/ZiggyCreatures.FusionCache.Serialization.ProtoBufNet/ZiggyCreatures.FusionCache.Serialization.ProtoBufNet.csproj
@@ -26,7 +26,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="protobuf-net" Version="3.2.45" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/ZiggyCreatures.FusionCache.Serialization.ServiceStackJson/FusionCacheServiceStackJsonSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.ServiceStackJson/FusionCacheServiceStackJsonSerializer.cs
@@ -1,8 +1,11 @@
-﻿using System.IO;
+﻿using System;
+using System.Buffers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ServiceStack.Text;
-using IORSM = Microsoft.IO.RecyclableMemoryStreamManager;
+
+using ZiggyCreatures.Caching.Fusion.Internals;
 
 namespace ZiggyCreatures.Caching.Fusion.Serialization.ServiceStackJson;
 
@@ -12,17 +15,6 @@ namespace ZiggyCreatures.Caching.Fusion.Serialization.ServiceStackJson;
 public class FusionCacheServiceStackJsonSerializer
 	: IFusionCacheSerializer
 {
-	/// <summary>
-	/// The options class for the <see cref="FusionCacheServiceStackJsonSerializer"/> class.
-	/// </summary>
-	public class Options
-	{
-		/// <summary>
-		/// The optional <see cref="IORSM"/> object to use.
-		/// </summary>
-		public IORSM? StreamManager { get; set; }
-	}
-
 	static FusionCacheServiceStackJsonSerializer()
 	{
 		JsConfig.Init(new Config
@@ -34,37 +26,32 @@ public class FusionCacheServiceStackJsonSerializer
 	/// <summary>
 	/// Creates a new instance of a <see cref="FusionCacheServiceStackJsonSerializer"/> object.
 	/// </summary>
-	/// <param name="options">The optional <see cref="Options"/> object to use.</param>
-	public FusionCacheServiceStackJsonSerializer(Options? options = null)
+	public FusionCacheServiceStackJsonSerializer()
 	{
-		_streamManager = options?.StreamManager;
-	}
-
-	private readonly IORSM? _streamManager;
-
-	private MemoryStream GetMemoryStream()
-	{
-		return _streamManager?.GetStream() ?? new MemoryStream();
-	}
-
-	private MemoryStream GetMemoryStream(byte[] buffer)
-	{
-		return _streamManager?.GetStream(buffer) ?? new MemoryStream(buffer);
 	}
 
 	/// <inheritdoc />
 	public byte[] Serialize<T>(T? obj)
 	{
-		using var stream = GetMemoryStream();
+		using var stream = new ArrayPoolWritableStream();
 		JsonSerializer.SerializeToStream<T?>(obj, stream);
-		return stream.ToArray();
+		return stream.GetBytes();
 	}
 
 	/// <inheritdoc />
 	public T? Deserialize<T>(byte[] data)
 	{
-		using var stream = GetMemoryStream(data);
-		return JsonSerializer.DeserializeFromStream<T?>(stream);
+		int numChars = Encoding.UTF8.GetCharCount(data);
+		var chars = ArrayPool<char>.Shared.Rent(numChars);
+		try
+		{
+			Encoding.UTF8.GetChars(data, 0, data.Length, chars, 0);
+			return JsonSerializer.DeserializeFromSpan<T?>(chars.AsSpan(0, numChars));
+		}
+		finally
+		{
+			ArrayPool<char>.Shared.Return(chars);
+		}
 	}
 
 	/// <inheritdoc />

--- a/src/ZiggyCreatures.FusionCache.Serialization.ServiceStackJson/FusionCacheServiceStackJsonSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.ServiceStackJson/FusionCacheServiceStackJsonSerializer.cs
@@ -76,5 +76,5 @@ public class FusionCacheServiceStackJsonSerializer
 	}
 
 	/// <inheritdoc />
-	public override string ToString() => $"{(_streamManager != null ? "Recyclable" : "")}{GetType().Name}";
+	public override string ToString() => GetType().Name;
 }

--- a/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/FusionCacheSystemTextJsonSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/FusionCacheSystemTextJsonSerializer.cs
@@ -1,8 +1,10 @@
-﻿using System.IO;
+﻿using System.Collections.Concurrent;
+using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.IO;
+
+using ZiggyCreatures.Caching.Fusion.Internals;
 
 namespace ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson;
 
@@ -21,11 +23,6 @@ public class FusionCacheSystemTextJsonSerializer
 		/// The optional <see cref="JsonSerializerOptions"/> object to use.
 		/// </summary>
 		public JsonSerializerOptions? SerializerOptions { get; set; }
-
-		/// <summary>
-		/// The optional <see cref="RecyclableMemoryStreamManager"/> object to use.
-		/// </summary>
-		public RecyclableMemoryStreamManager? StreamManager { get; set; }
 	}
 
 	/// <summary>
@@ -44,21 +41,9 @@ public class FusionCacheSystemTextJsonSerializer
 	public FusionCacheSystemTextJsonSerializer(Options? options)
 		: this(options?.SerializerOptions)
 	{
-		_streamManager = options?.StreamManager;
 	}
 
 	private readonly JsonSerializerOptions? _serializerOptions;
-	private readonly RecyclableMemoryStreamManager? _streamManager;
-
-	private MemoryStream GetMemoryStream()
-	{
-		return _streamManager?.GetStream() ?? new MemoryStream();
-	}
-
-	private MemoryStream GetMemoryStream(byte[] buffer)
-	{
-		return _streamManager?.GetStream(buffer) ?? new MemoryStream(buffer);
-	}
 
 	/// <inheritdoc />
 	public byte[] Serialize<T>(T? obj)
@@ -73,18 +58,15 @@ public class FusionCacheSystemTextJsonSerializer
 	}
 
 	/// <inheritdoc />
-	public async ValueTask<byte[]> SerializeAsync<T>(T? obj, CancellationToken token = default)
+	public ValueTask<byte[]> SerializeAsync<T>(T? obj, CancellationToken token = default)
 	{
-		using var stream = GetMemoryStream();
-		await JsonSerializer.SerializeAsync<T?>(stream, obj, _serializerOptions, token);
-		return stream.ToArray();
+		return new ValueTask<byte[]>(Serialize(obj));
 	}
 
 	/// <inheritdoc />
-	public async ValueTask<T?> DeserializeAsync<T>(byte[] data, CancellationToken token = default)
+	public ValueTask<T?> DeserializeAsync<T>(byte[] data, CancellationToken token = default)
 	{
-		using var stream = GetMemoryStream(data);
-		return await JsonSerializer.DeserializeAsync<T>(stream, _serializerOptions, token);
+		return new ValueTask<T?>(Deserialize<T>(data));
 	}
 
 	/// <inheritdoc />

--- a/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/FusionCacheSystemTextJsonSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/FusionCacheSystemTextJsonSerializer.cs
@@ -70,5 +70,5 @@ public class FusionCacheSystemTextJsonSerializer
 	}
 
 	/// <inheritdoc />
-	public override string ToString() => $"{(_streamManager != null ? "Recyclable" : "")}{GetType().Name}";
+	public override string ToString() => GetType().Name;
 }

--- a/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/ZiggyCreatures.FusionCache.Serialization.SystemTextJson.csproj
+++ b/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/ZiggyCreatures.FusionCache.Serialization.SystemTextJson.csproj
@@ -26,7 +26,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolBufferWriter.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolBufferWriter.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace ZiggyCreatures.Caching.Fusion.Internals
+{
+	/// <summary>
+	/// The <see cref="ArrayPoolBufferWriter"/> class is an implementation of <see cref="T:IBufferWriter{byte}"/> that uses an <see cref="T:ArrayPool{byte}"/> to rent and return buffers.
+	/// </summary>
+	public class ArrayPoolBufferWriter : IBufferWriter<byte>
+	{
+		private static readonly ConcurrentStack<ArrayPoolBufferWriter> PooledWriters = new();
+		
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static ArrayPoolBufferWriter Rent()
+		{
+			return PooledWriters.TryPop(out var writer) ? writer : new ArrayPoolBufferWriter();
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static void Return(ArrayPoolBufferWriter writer)
+		{
+			writer.Reset();
+			PooledWriters.Push(writer);
+		}
+
+		private static readonly ArrayPool<byte> _arrayPool = ArrayPool<byte>.Create();
+		private byte[] _buffer;
+		private int _bytesWritten = 0;
+		/// <summary>
+		/// Gets the number of bytes written to the buffer.
+		/// </summary>
+		public int BytesWritten => _bytesWritten;
+		
+		/// <summary>
+		/// Gets the size of the buffer.
+		/// </summary>
+		public int BufferSize => _buffer.Length;
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="ArrayPoolBufferWriter"/> class.
+		/// </summary>
+		private ArrayPoolBufferWriter()
+		{
+			_buffer = _arrayPool.Rent(4096);
+		}
+
+		/// <inheritdoc/>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public void Advance(int count)
+		{
+			if (_bytesWritten + count > _buffer.Length)
+			{
+				ThrowInvalidOperationException();
+			}
+
+			_bytesWritten += count;
+		}
+
+		/// <summary>
+		/// Resets the buffer writer.
+		/// </summary>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private void Reset()
+		{
+			_bytesWritten = 0;
+		}
+
+		/// <inheritdoc/>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Memory<byte> GetMemory(int sizeHint = 0)
+		{
+			var requiredCapacity = _bytesWritten + sizeHint;
+			var currentBufferLength = _buffer.Length;
+			if (requiredCapacity >= currentBufferLength)
+			{
+				var newSize = Math.Max(currentBufferLength * 2, requiredCapacity);
+				var newBuffer = _arrayPool.Rent(newSize);
+				var bufferSpan = _buffer.AsSpan();
+				var newBufferSpan = newBuffer.AsSpan();
+				Unsafe.CopyBlockUnaligned(ref MemoryMarshal.GetReference(newBufferSpan), ref MemoryMarshal.GetReference(bufferSpan), (uint)_bytesWritten);
+				_arrayPool.Return(_buffer);
+				_buffer = newBuffer;
+			}
+
+			return _buffer.AsMemory(_bytesWritten);
+		}
+
+		/// <summary>
+		/// Returns the buffer as an array of <see cref="T:byte[]" />
+		/// </summary>
+		/// <returns>The buffer as a byte array.</returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public byte[] ToArray()
+		{
+			var bufferSpan = _buffer.AsSpan(0, _bytesWritten);
+			byte[] result = new byte[_bytesWritten];
+			var resultSpan = result.AsSpan();
+			Unsafe.CopyBlockUnaligned(ref MemoryMarshal.GetReference(resultSpan), ref MemoryMarshal.GetReference(bufferSpan), (uint)_bytesWritten);
+			return result;
+		}
+
+		/// <inheritdoc/>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Span<byte> GetSpan(int sizeHint = 0)
+		{
+			return GetMemory(sizeHint).Span;
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static void ThrowInvalidOperationException()
+		{
+			throw new InvalidOperationException("Cannot advance past the end of the buffer.");
+		}
+	}
+}

--- a/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolBufferWriter.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolBufferWriter.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Buffers;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace ZiggyCreatures.Caching.Fusion.Internals
 {
@@ -22,7 +19,7 @@ namespace ZiggyCreatures.Caching.Fusion.Internals
 		/// Gets the number of bytes written to the buffer.
 		/// </summary>
 		public int BytesWritten => _bytesWritten;
-		
+
 		/// <summary>
 		/// Gets the size of the buffer.
 		/// </summary>

--- a/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolWritableStream.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolWritableStream.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace ZiggyCreatures.Caching.Fusion.Internals
+{
+	/// <summary>
+	/// A writable stream that uses an <see cref="ArrayPoolBufferWriter"/> to manage its buffer.
+	/// </summary>
+	public class ArrayPoolWritableStream : Stream
+	{
+		private readonly ArrayPoolBufferWriter _buffer;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ArrayPoolWritableStream"/> class.
+		/// </summary>
+		public ArrayPoolWritableStream()
+		{
+			_buffer = ArrayPoolBufferWriter.Rent();
+		}
+
+		/// <inheritdoc/>
+		public override bool CanRead => false;
+
+		/// <inheritdoc/>
+		public override bool CanSeek => false;
+
+		/// <inheritdoc/>
+		public override bool CanWrite => true;
+
+		/// <inheritdoc/>
+		public override long Length => _buffer.BytesWritten;
+
+		/// <summary>
+		/// Gets the written bytes as a byte array.
+		/// </summary>
+		/// <returns>The written bytes as a byte array.</returns>
+		public byte[] GetBytes() => _buffer.ToArray();
+
+		/// <inheritdoc/>
+		public override long Position
+		{
+			get => Length;
+			set
+			{
+				throw new NotSupportedException("Cannot set the position of a writable stream.");
+			}
+		}
+
+		/// <inheritdoc/>
+		public override void Flush()
+		{
+			// no-op
+			return;
+		}
+
+		/// <inheritdoc/>
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			throw new NotSupportedException("Cannot read from a writable stream.");
+		}
+
+		/// <inheritdoc/>
+		public override long Seek(long offset, SeekOrigin origin)
+		{
+			throw new NotSupportedException("Cannot seek a writable stream.");
+		}
+
+		/// <inheritdoc/>
+		public override void SetLength(long value)
+		{
+			throw new NotSupportedException("Cannot set the length of a writable stream.");
+		}
+
+		/// <inheritdoc/>
+		public override void Write(byte[] buffer, int offset, int count)
+		{
+			var memory = _buffer.GetSpan(count);
+			buffer.AsSpan(offset, count).CopyTo(memory);
+			_buffer.Advance(count);
+		}
+
+		/// <summary>
+		/// Releases the unmanaged resources used by the <see cref="ArrayPoolWritableStream"/> and optionally releases the managed resources.
+		/// </summary>
+		/// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				ArrayPoolBufferWriter.Return(_buffer);
+			}
+		}
+	}
+}

--- a/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolWritableStream.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolWritableStream.cs
@@ -17,7 +17,7 @@ namespace ZiggyCreatures.Caching.Fusion.Internals
 		/// </summary>
 		public ArrayPoolWritableStream()
 		{
-			_buffer = ArrayPoolBufferWriter.Rent();
+			_buffer = new ArrayPoolBufferWriter();
 		}
 
 		/// <inheritdoc/>
@@ -89,7 +89,7 @@ namespace ZiggyCreatures.Caching.Fusion.Internals
 		{
 			if (disposing)
 			{
-				ArrayPoolBufferWriter.Return(_buffer);
+				_buffer.Dispose();
 			}
 		}
 	}

--- a/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolWritableStream.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolWritableStream.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Buffers;
-using System.Collections.Concurrent;
 using System.IO;
 
 namespace ZiggyCreatures.Caching.Fusion.Internals

--- a/tests/ZiggyCreatures.FusionCache.Tests/LoggingTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/LoggingTests.cs
@@ -24,7 +24,7 @@ public class LoggingTests
 	}
 
 	[Fact]
-	public async Task CommonLogLevelsWork()
+	public void CommonLogLevelsWork()
 	{
 		var logger = CreateListLogger<FusionCache>(LogLevel.Debug);
 		using (var cache = new FusionCache(new FusionCacheOptions(), logger: logger))
@@ -44,7 +44,7 @@ public class LoggingTests
 	}
 
 	[Fact]
-	public async Task PluginsInfoWork()
+	public void PluginsInfoWork()
 	{
 		var logger = CreateListLogger<FusionCache>(LogLevel.Information);
 		var options = new FusionCacheOptions();
@@ -69,7 +69,7 @@ public class LoggingTests
 	}
 
 	[Fact]
-	public async Task EventsErrorsLogLevelsWork()
+	public void EventsErrorsLogLevelsWork()
 	{
 		var logger = CreateListLogger<FusionCache>(LogLevel.Information);
 		var options = new FusionCacheOptions

--- a/tests/ZiggyCreatures.FusionCache.Tests/SerializationTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/SerializationTests.cs
@@ -11,7 +11,7 @@ using ZiggyCreatures.Caching.Fusion.Serialization;
 
 namespace FusionCacheTests;
 
-public class SerializationTests
+public partial class SerializationTests
 	: AbstractTests
 {
 	public SerializationTests(ITestOutputHelper output)
@@ -19,7 +19,7 @@ public class SerializationTests
 	{
 	}
 
-	private static readonly Regex __re_VersionExtractor = new Regex(@"\w+__v(\d+_\d+_\d+)_\d+\.bin", RegexOptions.Compiled);
+	private static readonly Regex __re_VersionExtractor = VersionExtractorRegEx();
 
 	private const string SampleString = "Supercalifragilisticexpialidocious";
 
@@ -266,7 +266,7 @@ public class SerializationTests
 
 		var assembly = serializer.GetType().Assembly;
 		var fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location);
-		string? currentVersion = fvi.FileVersion!.Substring(0, fvi.FileVersion.LastIndexOf('.'));
+		string? currentVersion = fvi.FileVersion![..fvi.FileVersion!.LastIndexOf('.')];
 
 		var filePrefix = $"{serializer.GetType().Name}__";
 
@@ -294,7 +294,7 @@ public class SerializationTests
 
 		var assembly = serializer.GetType().Assembly;
 		var fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location);
-		string? currentVersion = fvi.FileVersion!.Substring(0, fvi.FileVersion.LastIndexOf('.'));
+		string? currentVersion = fvi.FileVersion![..fvi.FileVersion!.LastIndexOf('.')];
 
 		var filePrefix = $"{serializer.GetType().Name}__";
 
@@ -313,4 +313,7 @@ public class SerializationTests
 			TestOutput.WriteLine($"Correctly deserialized payload from v{payloadVersion} to v{currentVersion} (current) using {serializer.GetType().Name}");
 		}
 	}
+
+	[GeneratedRegex(@"\w+__v(\d+_\d+_\d+)_\d+\.bin", RegexOptions.Compiled)]
+	private static partial Regex VersionExtractorRegEx();
 }

--- a/tests/ZiggyCreatures.FusionCache.Tests/Stuff/TestsUtils.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/Stuff/TestsUtils.cs
@@ -35,28 +35,13 @@ public static class TestsUtils
 			case SerializerType.NewtonsoftJson:
 				return new FusionCacheNewtonsoftJsonSerializer();
 			case SerializerType.SystemTextJson:
-				// NOTE: WE USE THE VERSION WITH THE RecyclableMemoryStreamManager BECAUSE
-				// IF THIS WORKS, THEN IT WORKS THE "BASIC" ONE FOR SURE
-				return new FusionCacheSystemTextJsonSerializer(new FusionCacheSystemTextJsonSerializer.Options
-				{
-					StreamManager = new RecyclableMemoryStreamManager()
-				});
+				return new FusionCacheSystemTextJsonSerializer();
 			case SerializerType.ServiceStackJson:
-				// NOTE: WE USE THE VERSION WITH THE RecyclableMemoryStreamManager BECAUSE
-				// IF THIS WORKS, THEN IT WORKS THE "BASIC" ONE FOR SURE
-				return new FusionCacheServiceStackJsonSerializer(new FusionCacheServiceStackJsonSerializer.Options
-				{
-					StreamManager = new RecyclableMemoryStreamManager()
-				});
+				return new FusionCacheServiceStackJsonSerializer();
 			case SerializerType.NeueccMessagePack:
 				return new FusionCacheNeueccMessagePackSerializer();
 			case SerializerType.ProtoBufNet:
-				// NOTE: WE USE THE VERSION WITH THE RecyclableMemoryStreamManager BECAUSE
-				// IF THIS WORKS, THEN IT WORKS THE "BASIC" ONE FOR SURE
-				return new FusionCacheProtoBufNetSerializer(new FusionCacheProtoBufNetSerializer.Options
-				{
-					StreamManager = new RecyclableMemoryStreamManager()
-				});
+				return new FusionCacheProtoBufNetSerializer();
 			case SerializerType.CysharpMemoryPack:
 				return new FusionCacheCysharpMemoryPackSerializer();
 			default:

--- a/tests/ZiggyCreatures.FusionCache.Tests/Stuff/XUnitLogger.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/Stuff/XUnitLogger.cs
@@ -42,7 +42,7 @@ public class XUnitLogger<T>
 		{
 			_helper.WriteLine(
 				(logLevel >= LogLevel.Warning ? Environment.NewLine : "")
-				+ $"{logLevel.ToString().Substring(0, 4).ToUpper()} {DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK", CultureInfo.InvariantCulture)}: "
+				+ $"{logLevel.ToString()[..4].ToUpper()} {DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK", CultureInfo.InvariantCulture)}: "
 				+ formatter(state, exception)
 				+ (exception is null
 					? ""


### PR DESCRIPTION
Main changes:
* Remove dependency on `Microsoft.IO.RecyclableMemoryStream` and replaces that with implementations based on `IBufferWriter<byte>` and `ArrayPool<byte>`
* Use `AggressiveInlining` where appropriate
* Use better optimized methods when serializers support them (like using `IBufferWriter<byte>` instances where applicable etc.)
* `(De)SerializeAsync` methods just call the non-async versions since this never does any I/O so async becomes pure overhead.
* Use Stream/Array pooling where appropriate

# Runner Information
```

BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.2605)
Unknown processor
.NET SDK 9.0.101
 [Host] : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Toolchain=InProcessEmitToolchain 

```

# CysharpMemoryPack
| Method                    |      Mean |    Error |   StdDev |       P95 |  Gen0 |  Gen1 |  Gen2 | Allocated |
| ------------------------- | --------: | -------: | -------: | --------: | ----: | ----: | ----: | --------: |
| Serialize - Before        | 105.56 μs | 2.094 μs | 2.936 μs | 109.40 μs | 30.27 | 30.27 | 30.27 |  94.79 KB |
| Serialize - After         | 104.10 μs | 2.077 μs | 4.602 μs | 109.93 μs | 30.27 | 30.27 | 30.27 |  94.93 KB |
| Deserialize - Before      |  59.60 μs | 1.184 μs | 3.377 μs |  63.59 μs | 21.67 |  7.02 |     - | 265.68 KB |
| Deserialize - After       |  53.55 μs | 1.064 μs | 2.590 μs |  57.84 μs | 21.67 |  7.02 |     - | 265.68 KB |
| SerializeAsync - Before   |  96.91 μs | 0.188 μs | 0.166 μs |  97.14 μs | 30.27 | 30.27 | 30.27 |  94.79 KB |
| SerializeAsync - After    |  92.67 μs | 1.757 μs | 1.644 μs |  93.85 μs | 30.27 | 30.27 | 30.27 |  94.93 KB |
| DeserializeAsync - Before |  52.47 μs | 1.024 μs | 1.219 μs |  53.37 μs | 21.67 |  7.02 |     - | 265.68 KB |
| DeserializeAsync - After  |  50.08 μs | 0.178 μs | 0.139 μs |  50.26 μs | 21.67 |  7.02 |     - | 265.68 KB |

# NeueccMessagePack
| Method                    |      Mean |    Error |   StdDev |       P95 |  Gen0 | Gen1 | Gen2 | Allocated |
| ------------------------- | --------: | -------: | -------: | --------: | ----: | ---: | ---: | --------: |
| Serialize - Before        | 134.03 μs | 2.584 μs | 3.449 μs | 141.49 μs |  5.62 |    - |    - |  71.59 KB |
| Serialize - After         | 130.03 μs | 2.558 μs | 3.829 μs | 134.84 μs |  5.62 | 0.73 |    - |  71.62 KB |
| Deserialize - Before      | 228.95 μs | 3.776 μs | 3.347 μs | 231.19 μs | 21.48 | 6.84 |    - | 265.68 KB |
| Deserialize - After       | 210.79 μs | 4.098 μs | 4.208 μs | 213.72 μs | 21.48 | 6.84 |    - | 265.68 KB |
| SerializeAsync - Before   | 129.47 μs | 1.940 μs | 1.906 μs | 132.96 μs |  5.62 |    - |    - |  71.38 KB |
| SerializeAsync - After    | 132.82 μs | 2.454 μs | 2.296 μs | 134.70 μs |  5.62 | 0.98 |    - |  71.41 KB |
| DeserializeAsync - Before | 212.83 μs | 3.359 μs | 4.248 μs | 223.17 μs | 21.48 | 6.84 |    - | 265.68 KB |
| DeserializeAsync - After  | 220.15 μs | 4.187 μs | 6.394 μs | 228.99 μs | 21.48 | 6.84 |    - | 265.68 KB |

# NewtonsoftJson
| Method                    |        Mean |     Error |    StdDev |         P95 |   Gen0 |   Gen1 |   Gen2 |  Allocated |
| ------------------------- | ----------: | --------: | --------: | ----------: | -----: | -----: | -----: | ---------: |
| Serialize - Before        | 1,196.11 μs |  8.743 μs |  8.178 μs | 1,206.85 μs | 132.81 | 132.81 | 132.82 | 1058.87 KB |
| Serialize - After         |   982.74 μs |  8.041 μs |  6.715 μs |   991.35 μs |  44.92 |  44.92 |  44.92 |  472.39 KB |
| Deserialize - Before      | 1,714.11 μs | 17.194 μs | 14.358 μs | 1,730.95 μs |  89.84 |  89.84 |  89.84 |  956.01 KB |
| Deserialize - After       | 1,565.65 μs | 30.581 μs | 36.404 μs | 1,593.10 μs |  52.73 |  17.58 |      - |  664.50 KB |
| SerializeAsync - Before   | 1,170.13 μs | 15.676 μs | 14.663 μs | 1,194.89 μs | 132.81 | 132.82 | 132.81 | 1058.84 KB |
| SerializeAsync - After    | 1,098.00 μs | 21.695 μs | 33.776 μs | 1,150.39 μs |  44.92 |  44.92 |  44.92 |  472.36 KB |
| DeserializeAsync - Before | 1,873.96 μs | 27.709 μs | 25.919 μs | 1,889.38 μs |  89.84 |  89.84 |  89.84 |  956.37 KB |
| DeserializeAsync - After  | 1,503.74 μs | 28.815 μs | 29.591 μs | 1,546.75 μs |  52.73 |  17.58 |      - |  664.73 KB |

# ProtoBufNet
| Method                    |      Mean |    Error |   StdDev |       P95 |  Gen0 | Gen1 | Gen2 | Allocated |
| ------------------------- | --------: | -------: | -------: | --------: | ----: | ---: | ---: | --------: |
| Serialize - Before        | 272.91 μs | 5.197 μs | 5.104 μs | 283.40 μs |  5.86 |    - |    - |  78.15 KB |
| Serialize - After         | 257.61 μs | 1.529 μs | 1.193 μs | 258.70 μs |  5.86 |    - |    - |  77.94 KB |
| Deserialize - Before      | 415.35 μs | 2.054 μs | 1.604 μs | 417.54 μs | 21.48 | 6.84 |    - | 265.99 KB |
| Deserialize - After       | 374.51 μs | 4.100 μs | 3.201 μs | 379.65 μs | 21.48 | 6.84 |    - | 265.71 KB |
| SerializeAsync - Before   | 261.92 μs | 3.084 μs | 3.300 μs | 268.50 μs |  5.86 |    - |    - |  78.13 KB |
| SerializeAsync - After    | 264.19 μs | 1.083 μs | 0.960 μs | 265.26 μs |  5.86 |    - |    - |  77.95 KB |
| DeserializeAsync - Before | 391.25 μs | 6.817 μs | 6.043 μs | 400.76 μs | 21.48 | 6.84 |    - | 265.99 KB |
| DeserializeAsync - After  | 371.55 μs | 1.868 μs | 1.458 μs | 373.18 μs | 21.48 | 6.84 |    - | 265.71 KB |

# ServiceStackJson
| Method                    |        Mean |     Error |    StdDev |         P95 |   Gen0 |  Gen1 |  Gen2 | Allocated |
| ------------------------- | ----------: | --------: | --------: | ----------: | -----: | ----: | ----: | --------: |
| Serialize - Before        |   951.66 μs |  8.324 μs |  6.499 μs |   960.35 μs |  93.75 | 46.88 | 46.88 | 918.06 KB |
| Serialize - After         | 1,110.08 μs | 21.414 μs | 22.913 μs | 1,129.70 μs |  93.75 | 46.88 | 46.88 | 919.08 KB |
| Deserialize - Before      | 3,155.60 μs | 16.833 μs | 14.922 μs | 3,172.18 μs |  39.06 | 11.72 |     - | 517.84 KB |
| Deserialize - After       | 3,072.51 μs | 60.461 μs | 82.760 μs | 3,198.14 μs |  39.06 | 11.72 |     - | 516.22 KB |
| SerializeAsync - Before   | 1,261.15 μs | 23.705 μs | 21.014 μs | 1,286.96 μs | 103.52 | 41.02 | 41.02 | 918.45 KB |
| SerializeAsync - After    | 1,039.95 μs |  5.062 μs |  4.735 μs | 1,045.45 μs |  93.75 | 46.88 | 46.88 | 915.11 KB |
| DeserializeAsync - Before | 3,021.69 μs | 13.353 μs | 11.837 μs | 3,039.19 μs |  39.06 | 11.72 |     - | 517.84 KB |
| DeserializeAsync - After  | 3,378.36 μs | 43.456 μs | 40.649 μs | 3,398.41 μs |  39.06 | 11.72 |     - | 516.22 KB |

# SystemTextJson

| Method                    |        Mean |     Error |    StdDev |         P95 |  Gen0 |  Gen1 |  Gen2 | Allocated |
| ------------------------- | ----------: | --------: | --------: | ----------: | ----: | ----: | ----: | --------: |
| Serialize - Before        |   401.76 μs |  1.727 μs |  1.615 μs |   403.71 μs | 41.02 | 41.02 | 41.02 | 146.87 KB |
| Serialize - After         |   391.87 μs |  3.665 μs |  3.428 μs |   396.84 μs | 39.55 | 39.55 | 39.55 | 146.90 KB |
| Deserialize - Before      |   793.84 μs |  6.847 μs |  5.717 μs |   799.79 μs | 31.25 |  9.77 |     - | 391.67 KB |
| Deserialize - After       |   782.21 μs | 14.931 μs | 14.665 μs |   801.80 μs | 31.25 |  9.77 |     - | 391.67 KB |
| SerializeAsync - Before   |   377.48 μs |  0.936 μs |  0.830 μs |   378.88 μs | 42.48 | 42.48 | 42.48 | 147.40 KB |
| SerializeAsync - After    |   352.10 μs |  0.950 μs |  0.889 μs |   353.30 μs | 39.55 | 39.55 | 39.55 | 146.89 KB |
| DeserializeAsync - Before | 1,117.59 μs |  5.602 μs |  4.966 μs | 1,121.62 μs | 31.25 |  9.77 |     - | 391.98 KB |
| DeserializeAsync - After  |   823.95 μs | 16.018 μs | 22.455 μs |   843.89 μs | 31.25 |  9.77 |     - | 391.67 KB |