### PR TITLE
[FEATURE] Key-dependent cache entry options

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -140,6 +140,7 @@ All these informations are fully available via IntelliSense, auto-suggest or sim
 | ---: | :---: | :---: | :--- |
 | `CacheName`                                 | `string` | `"FusionCache"` | The name of the cache: it can be used for identification, and in a multi-node scenario it is typically shared between nodes to create a logical association. |
 | `DefaultEntryOptions`                       | `FusionCacheEntryOptions`  | *see below* | This is the default entry options object that will be used when one is not passed to each method call that need one, and as a starting point when duplicating one, either via the explicit `FusionCache.CreateOptions(...)` method or in one of the *overloads* of each *core method*. |
+| `KeyDependentEntryOptions`                  | `KeyDependentFusionCacheEntryOptions[]` | `[]` | entry options overrides for specific key prefixes.
 | `DistributedCacheCircuitBreakerDuration`    | `TimeSpan`                 | `none` | The duration of the circuit-breaker used when working with the distributed cache. |
 | `CacheKeyPrefix`           | `string?`     | `null` | A prefix that will be added to each cache key for each call: it can be useful when working with multiple named caches. With the builder it can be set using the `WithCacheKeyPrefix(...)` method. |
 | `DistributedCacheKeyModifierMode`           | `CacheKeyModifierMode`     | `Prefix` | Specify the mode in which cache key will be changed for the distributed cache (eg: to specify the wire format version). |

--- a/src/ZiggyCreatures.FusionCache/FusionCacheBuilderExtMethods.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheBuilderExtMethods.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ZiggyCreatures.Caching.Fusion.Backplane;
+using ZiggyCreatures.Caching.Fusion.Internals.Builder;
 using ZiggyCreatures.Caching.Fusion.Locking;
 using ZiggyCreatures.Caching.Fusion.MicrosoftHybridCache;
 using ZiggyCreatures.Caching.Fusion.Plugins;
@@ -726,6 +727,27 @@ public static partial class FusionCacheBuilderExtMethods
 		builder.MemoryLockerFactory = factory;
 		builder.ThrowIfMissingMemoryLocker = true;
 
+		return builder;
+	}
+
+	/// <summary>
+	/// Specify custom configuration for <see cref="IKeyedFusionCacheEntryOptionsProvider" /> registration. />
+	/// </summary>
+	/// <param name="builder">The <see cref="IFusionCacheBuilder" /> to act upon.</param>
+	/// <param name="config">The configuration action to adjust the registration.</param>
+	/// <returns>The <see cref="IFusionCacheBuilder"/> so that additional calls can be chained.</returns>
+	public static IFusionCacheBuilder WithKeyDependentEntryOptionsProvider(
+		this IFusionCacheBuilder builder,
+		Action<CustomServiceRegistration<IKeyedFusionCacheEntryOptionsProvider>> config)
+	{
+		var registration = new CustomServiceRegistration<IKeyedFusionCacheEntryOptionsProvider>
+		{
+			ThrowIfMissing = true
+		};
+
+		config(registration);
+
+		builder.KeyDependentEntryOptionsProvider = registration;
 		return builder;
 	}
 

--- a/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_Basic_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_Basic_Async.cs
@@ -17,11 +17,11 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, TimeSpan duration, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -31,12 +31,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -46,11 +46,11 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -60,12 +60,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	#endregion
@@ -79,12 +79,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">The default value to return if the value for the given <paramref name="key"/> is not in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache or the <paramref name="defaultValue"/> .</returns>
 	public static ValueTask<TValue?> GetOrDefaultAsync<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, TValue? defaultValue = default, CancellationToken token = default)
 	{
-		return cache.GetOrDefaultAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		return cache.GetOrDefaultAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	/// <summary>
@@ -99,7 +99,7 @@ public static partial class FusionCacheExtMethods
 	/// <returns>The value in the cache or the <paramref name="defaultValue"/> .</returns>
 	public static ValueTask<TValue?> GetOrDefaultAsync<TValue>(this IFusionCache cache, string key, TValue? defaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 	{
-		return cache.GetOrDefaultAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		return cache.GetOrDefaultAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	#endregion
@@ -112,11 +112,11 @@ public static partial class FusionCacheExtMethods
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static ValueTask<MaybeValue<TValue>> TryGetAsync<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 	{
-		return cache.TryGetAsync<TValue>(key, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		return cache.TryGetAsync<TValue>(key, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	#endregion
@@ -130,12 +130,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
 	public static ValueTask SetAsync<TValue>(this IFusionCache cache, string key, TValue value, TimeSpan duration, CancellationToken token)
 	{
-		return cache.SetAsync<TValue>(key, value, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.SetAsync<TValue>(key, value, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -145,13 +145,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
 	public static ValueTask SetAsync<TValue>(this IFusionCache cache, string key, TValue value, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.SetAsync<TValue>(key, value, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.SetAsync<TValue>(key, value, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -161,12 +161,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
 	public static ValueTask SetAsync<TValue>(this IFusionCache cache, string key, TValue value, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.SetAsync<TValue>(key, value, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.SetAsync<TValue>(key, value, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -176,13 +176,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
 	public static ValueTask SetAsync<TValue>(this IFusionCache cache, string key, TValue value, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.SetAsync<TValue>(key, value, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.SetAsync<TValue>(key, value, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -192,7 +192,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="ValueTask"/> to await the completion of the operation.</returns>
 	public static ValueTask SetAsync<TValue>(this IFusionCache cache, string key, TValue value, FusionCacheEntryOptions? options, CancellationToken token)
@@ -209,12 +209,12 @@ public static partial class FusionCacheExtMethods
 	/// </summary>
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
 	public static ValueTask RemoveAsync(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 	{
-		return cache.RemoveAsync(key, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		return cache.RemoveAsync(key, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	#endregion
@@ -236,12 +236,12 @@ public static partial class FusionCacheExtMethods
 	/// </summary>
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="ValueTask"/> to await the completion of the operation.</returns>
 	public static ValueTask ExpireAsync(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 	{
-		return cache.ExpireAsync(key, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		return cache.ExpireAsync(key, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	#endregion

--- a/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_Basic_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_Basic_Sync.cs
@@ -16,11 +16,11 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, TValue defaultValue, TimeSpan duration, CancellationToken token)
 	{
-		return cache.GetOrSet<TValue>(key, defaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, defaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -30,12 +30,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, TValue defaultValue, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, defaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, defaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -45,11 +45,11 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, TValue defaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSet<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, defaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -59,12 +59,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, TValue defaultValue, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, defaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	#endregion
@@ -78,12 +78,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">The default value to return if the value for the given <paramref name="key"/> is not in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache or the <paramref name="defaultValue"/> .</returns>
 	public static TValue? GetOrDefault<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, TValue? defaultValue = default, CancellationToken token = default)
 	{
-		return cache.GetOrDefault<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		return cache.GetOrDefault<TValue>(key, defaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	/// <summary>
@@ -93,12 +93,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">The default value to return if the value for the given <paramref name="key"/> is not in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache or the <paramref name="defaultValue"/> .</returns>
 	public static TValue? GetOrDefault<TValue>(this IFusionCache cache, string key, TValue? defaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 	{
-		return cache.GetOrDefault<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		return cache.GetOrDefault<TValue>(key, defaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	#endregion
@@ -111,11 +111,11 @@ public static partial class FusionCacheExtMethods
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static MaybeValue<TValue> TryGet<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 	{
-		return cache.TryGet<TValue>(key, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		return cache.TryGet<TValue>(key, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	#endregion
@@ -129,11 +129,11 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static void Set<TValue>(this IFusionCache cache, string key, TValue value, TimeSpan duration, CancellationToken token)
 	{
-		cache.Set<TValue>(key, value, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		cache.Set<TValue>(key, value, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -143,12 +143,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static void Set<TValue>(this IFusionCache cache, string key, TValue value, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		cache.Set<TValue>(key, value, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		cache.Set<TValue>(key, value, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -158,11 +158,11 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static void Set<TValue>(this IFusionCache cache, string key, TValue value, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		cache.Set<TValue>(key, value, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		cache.Set<TValue>(key, value, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -172,12 +172,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static void Set<TValue>(this IFusionCache cache, string key, TValue value, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		cache.Set<TValue>(key, value, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		cache.Set<TValue>(key, value, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -187,7 +187,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static void Set<TValue>(this IFusionCache cache, string key, TValue value, FusionCacheEntryOptions? options, CancellationToken token)
 	{
@@ -203,11 +203,11 @@ public static partial class FusionCacheExtMethods
 	/// </summary>
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static void Remove(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 	{
-		cache.Remove(key, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		cache.Remove(key, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	#endregion
@@ -229,11 +229,11 @@ public static partial class FusionCacheExtMethods
 	/// </summary>
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	public static void Expire(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 	{
-		cache.Expire(key, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), token);
+		cache.Expire(key, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), token);
 	}
 
 	#endregion

--- a/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_FactoryNoCtx_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_FactoryNoCtx_Async.cs
@@ -18,7 +18,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, FusionCacheEntryOptions? options, CancellationToken token)
@@ -34,7 +34,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
@@ -51,12 +51,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created  <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -67,13 +67,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -84,12 +84,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -100,13 +100,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	#endregion
@@ -120,7 +120,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, FusionCacheEntryOptions? options, CancellationToken token)
@@ -135,7 +135,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
@@ -151,12 +151,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, TimeSpan duration, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), default, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -166,13 +166,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), default, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -182,12 +182,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -197,13 +197,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	#endregion

--- a/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_FactoryNoCtx_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_FactoryNoCtx_Sync.cs
@@ -17,7 +17,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, MaybeValue<TValue> failSafeDefaultValue, FusionCacheEntryOptions? options, CancellationToken token)
@@ -33,7 +33,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
@@ -50,12 +50,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, CancellationToken token)
 	{
-		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -66,13 +66,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -83,12 +83,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -99,13 +99,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), failSafeDefaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	#endregion
@@ -119,7 +119,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, FusionCacheEntryOptions? options, CancellationToken token)
@@ -134,7 +134,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
@@ -150,12 +150,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, TimeSpan duration, CancellationToken token)
 	{
-		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), default, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -165,13 +165,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), default, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -181,12 +181,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -196,13 +196,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<CancellationToken, TValue> factory, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, (_, ct) => factory(ct), default, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	#endregion

--- a/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_FactoryWithCtx_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_FactoryWithCtx_Async.cs
@@ -18,12 +18,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -34,13 +34,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -51,12 +51,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -67,13 +67,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -103,7 +103,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, FusionCacheEntryOptions? options, CancellationToken token)
@@ -118,7 +118,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
@@ -134,12 +134,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, TimeSpan duration, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, factory, default, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, factory, default, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -149,13 +149,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, factory, default, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, factory, default, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -165,12 +165,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSetAsync<TValue>(key, factory, default, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSetAsync<TValue>(key, factory, default, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -180,13 +180,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSetAsync<TValue>(key, factory, default, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSetAsync<TValue>(key, factory, default, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	#endregion

--- a/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_FactoryWithCtx_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods_FactoryWithCtx_Sync.cs
@@ -17,12 +17,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, CancellationToken token)
 	{
-		return cache.GetOrSet<TValue>(key, factory, failSafeDefaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -33,13 +33,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, factory, failSafeDefaultValue, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -50,12 +50,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSet<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -66,13 +66,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -102,7 +102,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, FusionCacheEntryOptions? options, CancellationToken token)
@@ -117,7 +117,7 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
@@ -133,12 +133,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, TimeSpan duration, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, factory, default, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, factory, default, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -148,13 +148,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, TimeSpan duration, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, factory, default, cache.DefaultEntryOptions.Duplicate(duration).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, factory, default, cache.CreateEntryOptions(key, duration: duration).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	/// <summary>
@@ -164,12 +164,12 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, Action<FusionCacheEntryOptions> setupAction, CancellationToken token)
 	{
-		return cache.GetOrSet<TValue>(key, factory, default, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
+		return cache.GetOrSet<TValue>(key, factory, default, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), FusionCacheInternalUtils.NoTags, token);
 	}
 
 	/// <summary>
@@ -179,13 +179,13 @@ public static partial class FusionCacheExtMethods
 	/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
-	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
+	/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="IFusionCache.DefaultEntryOptions"/>.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
 	public static TValue GetOrSet<TValue>(this IFusionCache cache, string key, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, Action<FusionCacheEntryOptions> setupAction, IEnumerable<string>? tags = null, CancellationToken token = default)
 	{
-		return cache.GetOrSet<TValue>(key, factory, default, cache.CreateEntryOptions(setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
+		return cache.GetOrSet<TValue>(key, factory, default, cache.CreateEntryOptions(key, setupAction).SetIsSafeForAdaptiveCaching(), tags, token);
 	}
 
 	#endregion

--- a/src/ZiggyCreatures.FusionCache/FusionCacheOptions.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Linq;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -16,6 +17,7 @@ public class FusionCacheOptions
 {
 	private string _cacheName;
 	private FusionCacheEntryOptions _defaultEntryOptions;
+	private KeyDependentFusionCacheEntryOptions[] _keyDependentDefaultEntryOptions;
 	private FusionCacheEntryOptions _tagsDefaultEntryOptions;
 
 	/// <summary>
@@ -61,6 +63,7 @@ public class FusionCacheOptions
 		_cacheName = DefaultCacheName;
 
 		_defaultEntryOptions = new FusionCacheEntryOptions();
+		_keyDependentDefaultEntryOptions = [];
 
 		_tagsDefaultEntryOptions = new FusionCacheEntryOptions
 		{
@@ -156,6 +159,18 @@ public class FusionCacheOptions
 
 			_defaultEntryOptions = value;
 		}
+	}
+
+	/// <summary>
+	/// The default <see cref="FusionCacheEntryOptions"/> per key template to use when none will be specified explicitly,
+	/// and as the starting point when duplicating one.
+	/// <br/><br/>
+	/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/Options.md"/>
+	/// </summary>
+	public KeyDependentFusionCacheEntryOptions[] KeyDependentEntryOptions
+	{
+		get { return _keyDependentDefaultEntryOptions ?? []; }
+		set { _keyDependentDefaultEntryOptions = value; }
 	}
 
 	/// <summary>
@@ -533,6 +548,9 @@ public class FusionCacheOptions
 			CacheKeyPrefix = CacheKeyPrefix,
 
 			DefaultEntryOptions = DefaultEntryOptions.Duplicate(),
+			KeyDependentEntryOptions = KeyDependentEntryOptions
+				.Select(opt => opt.Duplicate())
+				.ToArray(),
 			TagsDefaultEntryOptions = TagsDefaultEntryOptions.Duplicate(),
 
 			EnableAutoRecovery = EnableAutoRecovery,

--- a/src/ZiggyCreatures.FusionCache/FusionCache_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache_Async.cs
@@ -86,10 +86,8 @@ public partial class FusionCache
 		});
 	}
 
-	private async ValueTask<IFusionCacheMemoryEntry?> GetOrSetEntryInternalAsync<TValue>(string operationId, string key, string[]? tags, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, bool isRealFactory, MaybeValue<TValue> failSafeDefaultValue, FusionCacheEntryOptions? options, Activity? activity, CancellationToken token)
+	private async ValueTask<IFusionCacheMemoryEntry?> GetOrSetEntryInternalAsync<TValue>(string operationId, string key, string[]? tags, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, Task<TValue>> factory, bool isRealFactory, MaybeValue<TValue> failSafeDefaultValue, FusionCacheEntryOptions options, Activity? activity, CancellationToken token)
 	{
-		options ??= _defaultEntryOptions;
-
 		IFusionCacheMemoryEntry? memoryEntry = null;
 		bool memoryEntryIsValid = false;
 		object? memoryLockObj = null;
@@ -375,6 +373,7 @@ public partial class FusionCache
 
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		var tagsArray = tags.AsArray();
@@ -396,6 +395,7 @@ public partial class FusionCache
 
 		try
 		{
+			options ??= GetEntryOptions(unprefixedKey);
 			var entry = await GetOrSetEntryInternalAsync<TValue>(operationId, key, tagsArray, factory, true, failSafeDefaultValue, options, activity, token).ConfigureAwait(false);
 
 			if (entry is null)
@@ -426,6 +426,7 @@ public partial class FusionCache
 
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		var tagsArray = tags.AsArray();
@@ -444,6 +445,7 @@ public partial class FusionCache
 
 		try
 		{
+			options ??= GetEntryOptions(unprefixedKey);
 			var entry = await GetOrSetEntryInternalAsync<TValue>(operationId, key, tagsArray, (_, _) => Task.FromResult(defaultValue), false, default, options, activity, token).ConfigureAwait(false);
 
 			if (entry is null)
@@ -468,10 +470,8 @@ public partial class FusionCache
 
 	// TRY GET
 
-	private async ValueTask<IFusionCacheMemoryEntry?> TryGetEntryInternalAsync<TValue>(string operationId, string key, FusionCacheEntryOptions? options, Activity? activity, CancellationToken token)
+	private async ValueTask<IFusionCacheMemoryEntry?> TryGetEntryInternalAsync<TValue>(string operationId, string key, FusionCacheEntryOptions options, Activity? activity, CancellationToken token)
 	{
-		options ??= _defaultEntryOptions;
-
 		token.ThrowIfCancellationRequested();
 
 		IFusionCacheMemoryEntry? memoryEntry = null;
@@ -603,6 +603,7 @@ public partial class FusionCache
 
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		token.ThrowIfCancellationRequested();
@@ -617,6 +618,7 @@ public partial class FusionCache
 
 		try
 		{
+			options ??= GetEntryOptions(unprefixedKey);
 			var entry = await TryGetEntryInternalAsync<TValue>(operationId, key, options, activity, token).ConfigureAwait(false);
 
 			if (entry is null)
@@ -650,6 +652,7 @@ public partial class FusionCache
 
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		token.ThrowIfCancellationRequested();
@@ -664,6 +667,7 @@ public partial class FusionCache
 
 		try
 		{
+			options ??= GetEntryOptions(unprefixedKey);
 			var entry = await TryGetEntryInternalAsync<TValue>(operationId, key, options, activity, token).ConfigureAwait(false);
 
 			if (entry is null)
@@ -694,6 +698,7 @@ public partial class FusionCache
 	{
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		var tagsArray = tags.AsArray();
@@ -702,7 +707,7 @@ public partial class FusionCache
 
 		token.ThrowIfCancellationRequested();
 
-		options ??= _defaultEntryOptions;
+		options ??= GetEntryOptions(unprefixedKey);
 
 		var operationId = MaybeGenerateOperationId();
 
@@ -778,11 +783,12 @@ public partial class FusionCache
 	{
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		token.ThrowIfCancellationRequested();
 
-		options ??= _defaultEntryOptions;
+		options ??= GetEntryOptions(unprefixedKey);
 
 		await RemoveInternalAsync(key, options, token).ConfigureAwait(false);
 	}
@@ -827,11 +833,12 @@ public partial class FusionCache
 	{
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		token.ThrowIfCancellationRequested();
 
-		options ??= _defaultEntryOptions;
+		options ??= GetEntryOptions(unprefixedKey);
 
 		await ExpireInternalAsync(key, options, token).ConfigureAwait(false);
 	}

--- a/src/ZiggyCreatures.FusionCache/FusionCache_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache_Sync.cs
@@ -86,10 +86,8 @@ public partial class FusionCache
 		});
 	}
 
-	private IFusionCacheMemoryEntry? GetOrSetEntryInternal<TValue>(string operationId, string key, string[]? tags, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, bool isRealFactory, MaybeValue<TValue> failSafeDefaultValue, FusionCacheEntryOptions? options, Activity? activity, CancellationToken token)
+	private IFusionCacheMemoryEntry? GetOrSetEntryInternal<TValue>(string operationId, string key, string[]? tags, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, bool isRealFactory, MaybeValue<TValue> failSafeDefaultValue, FusionCacheEntryOptions options, Activity? activity, CancellationToken token)
 	{
-		options ??= _defaultEntryOptions;
-
 		IFusionCacheMemoryEntry? memoryEntry = null;
 		bool memoryEntryIsValid = false;
 		object? memoryLockObj = null;
@@ -375,6 +373,7 @@ public partial class FusionCache
 
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		var tagsArray = tags.AsArray();
@@ -396,6 +395,7 @@ public partial class FusionCache
 
 		try
 		{
+			options ??= GetEntryOptions(unprefixedKey);
 			var entry = GetOrSetEntryInternal<TValue>(operationId, key, tagsArray, factory, true, failSafeDefaultValue, options, activity, token);
 
 			if (entry is null)
@@ -426,6 +426,7 @@ public partial class FusionCache
 
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		var tagsArray = tags.AsArray();
@@ -444,6 +445,7 @@ public partial class FusionCache
 
 		try
 		{
+			options ??= GetEntryOptions(unprefixedKey);
 			var entry = GetOrSetEntryInternal<TValue>(operationId, key, tagsArray, (_, _) => defaultValue, false, default, options, activity, token);
 
 			if (entry is null)
@@ -468,10 +470,8 @@ public partial class FusionCache
 
 	// TRY GET
 
-	private IFusionCacheMemoryEntry? TryGetEntryInternal<TValue>(string operationId, string key, FusionCacheEntryOptions? options, Activity? activity, CancellationToken token)
+	private IFusionCacheMemoryEntry? TryGetEntryInternal<TValue>(string operationId, string key, FusionCacheEntryOptions options, Activity? activity, CancellationToken token)
 	{
-		options ??= _defaultEntryOptions;
-
 		token.ThrowIfCancellationRequested();
 
 		IFusionCacheMemoryEntry? memoryEntry = null;
@@ -603,6 +603,7 @@ public partial class FusionCache
 
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		token.ThrowIfCancellationRequested();
@@ -617,6 +618,7 @@ public partial class FusionCache
 
 		try
 		{
+			options ??= GetEntryOptions(unprefixedKey);
 			var entry = TryGetEntryInternal<TValue>(operationId, key, options, activity, token);
 
 			if (entry is null)
@@ -650,6 +652,7 @@ public partial class FusionCache
 
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		token.ThrowIfCancellationRequested();
@@ -664,6 +667,7 @@ public partial class FusionCache
 
 		try
 		{
+			options ??= GetEntryOptions(unprefixedKey);
 			var entry = TryGetEntryInternal<TValue>(operationId, key, options, activity, token);
 
 			if (entry is null)
@@ -694,6 +698,7 @@ public partial class FusionCache
 	{
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		var tagsArray = tags.AsArray();
@@ -702,7 +707,7 @@ public partial class FusionCache
 
 		token.ThrowIfCancellationRequested();
 
-		options ??= _defaultEntryOptions;
+		options ??= GetEntryOptions(unprefixedKey);
 
 		var operationId = MaybeGenerateOperationId();
 
@@ -778,11 +783,12 @@ public partial class FusionCache
 	{
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		token.ThrowIfCancellationRequested();
 
-		options ??= _defaultEntryOptions;
+		options ??= GetEntryOptions(unprefixedKey);
 
 		RemoveInternal(key, options, token);
 	}
@@ -827,11 +833,12 @@ public partial class FusionCache
 	{
 		ValidateCacheKey(key);
 
+		var unprefixedKey = key;
 		MaybePreProcessCacheKey(ref key);
 
 		token.ThrowIfCancellationRequested();
 
-		options ??= _defaultEntryOptions;
+		options ??= GetEntryOptions(unprefixedKey);
 
 		ExpireInternal(key, options, token);
 	}

--- a/src/ZiggyCreatures.FusionCache/IFusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/IFusionCache.cs
@@ -39,6 +39,15 @@ public interface IFusionCache
 	/// <returns>The newly created <see cref="FusionCacheEntryOptions"/>.</returns>
 	FusionCacheEntryOptions CreateEntryOptions(Action<FusionCacheEntryOptions>? setupAction = null, TimeSpan? duration = null);
 
+	/// <summary>
+	/// Creates a new <see cref="FusionCacheEntryOptions"/> instance by duplicating the <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> and optionally applying a setup action.
+	/// </summary>
+	/// <param name="key">The cache key which identifies the entry in the cache.</param>
+	/// <param name="setupAction">An optional setup action to further configure the newly created <see cref="FusionCacheEntryOptions"/> instance.</param>
+	/// <param name="duration">An optional duration to directly change the <see cref="FusionCacheEntryOptions.Duration"/> of the newly created <see cref="FusionCacheEntryOptions"/> instance.</param>
+	/// <returns>The newly created <see cref="FusionCacheEntryOptions"/>.</returns>
+	FusionCacheEntryOptions CreateEntryOptions(string key, Action<FusionCacheEntryOptions>? setupAction = null, TimeSpan? duration = null);
+
 	// GET OR SET
 
 	/// <summary>
@@ -48,7 +57,7 @@ public interface IFusionCache
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
@@ -61,7 +70,7 @@ public interface IFusionCache
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="factory">The function which will be called if the value is not found in the cache.</param>
 	/// <param name="failSafeDefaultValue">In case fail-safe is activated and there's no stale data to use, this value will be used instead of throwing an exception.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
@@ -73,7 +82,7 @@ public interface IFusionCache
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	ValueTask<TValue> GetOrSetAsync<TValue>(string key, TValue defaultValue, FusionCacheEntryOptions? options = null, IEnumerable<string>? tags = null, CancellationToken token = default);
@@ -84,7 +93,7 @@ public interface IFusionCache
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	TValue GetOrSet<TValue>(string key, TValue defaultValue, FusionCacheEntryOptions? options = null, IEnumerable<string>? tags = null, CancellationToken token = default);
@@ -97,7 +106,7 @@ public interface IFusionCache
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">The default value to return if the value for the given <paramref name="key"/> is not in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache or the <paramref name="defaultValue"/> .</returns>
 	ValueTask<TValue?> GetOrDefaultAsync<TValue>(string key, TValue? defaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default);
@@ -108,7 +117,7 @@ public interface IFusionCache
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="defaultValue">The default value to return if the value for the given <paramref name="key"/> is not in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>The value in the cache or the <paramref name="defaultValue"/> .</returns>
 	TValue? GetOrDefault<TValue>(string key, TValue? defaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default);
@@ -120,7 +129,7 @@ public interface IFusionCache
 	/// </summary>
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	ValueTask<MaybeValue<TValue>> TryGetAsync<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
@@ -129,7 +138,7 @@ public interface IFusionCache
 	/// </summary>
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	MaybeValue<TValue> TryGet<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
@@ -141,7 +150,7 @@ public interface IFusionCache
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="ValueTask"/> to await the completion of the operation.</returns>
@@ -153,7 +162,7 @@ public interface IFusionCache
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
 	/// <param name="value">The value to put in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="tags">The optional set of tags related to the entry: this may be used to remove/expire multiple entries at once, by tag.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	void Set<TValue>(string key, TValue value, FusionCacheEntryOptions? options = null, IEnumerable<string>? tags = null, CancellationToken token = default);
@@ -164,7 +173,7 @@ public interface IFusionCache
 	/// Removes the value in the cache for the specified <paramref name="key"/>.
 	/// </summary>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="ValueTask"/> to await the completion of the operation.</returns>
 	ValueTask RemoveAsync(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
@@ -173,7 +182,7 @@ public interface IFusionCache
 	/// Removes the value in the cache for the specified <paramref name="key"/>.
 	/// </summary>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	void Remove(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
@@ -186,7 +195,7 @@ public interface IFusionCache
 	/// In the distributed cache (if any), the entry will always be effectively removed.
 	/// </summary>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="ValueTask"/> to await the completion of the operation.</returns>
 	ValueTask ExpireAsync(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
@@ -198,7 +207,7 @@ public interface IFusionCache
 	/// In the distributed cache (if any), the entry will always be effectively removed.
 	/// </summary>
 	/// <param name="key">The cache key which identifies the entry in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.KeyDependentEntryOptions"/> or <see cref="DefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	void Expire(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
@@ -258,7 +267,7 @@ public interface IFusionCache
 	/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/Clear.md"/>
 	/// </summary>
 	/// <param name="allowFailSafe">If set to <see langword="true"/> it will expire all entries in the cache, if set to <see langword="false"/> it will remove all entries in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.TagsDefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	/// <returns>A <see cref="ValueTask"/> to await the completion of the operation.</returns>
 	ValueTask ClearAsync(bool allowFailSafe = true, FusionCacheEntryOptions? options = null, CancellationToken token = default);
@@ -273,7 +282,7 @@ public interface IFusionCache
 	/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/Clear.md"/>
 	/// </summary>
 	/// <param name="allowFailSafe">If set to <see langword="true"/> it will expire all entries in the cache, if set to <see langword="false"/> it will remove all entries in the cache.</param>
-	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
+	/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.TagsDefaultEntryOptions"/> will be used.</param>
 	/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 	void Clear(bool allowFailSafe = true, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 

--- a/src/ZiggyCreatures.FusionCache/IFusionCacheBuilder.cs
+++ b/src/ZiggyCreatures.FusionCache/IFusionCacheBuilder.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion.Backplane;
+using ZiggyCreatures.Caching.Fusion.Internals.Builder;
 using ZiggyCreatures.Caching.Fusion.Locking;
 using ZiggyCreatures.Caching.Fusion.Plugins;
 using ZiggyCreatures.Caching.Fusion.Serialization;
@@ -276,6 +277,11 @@ public interface IFusionCacheBuilder
 	List<Func<IServiceProvider, IFusionCachePlugin>> PluginsFactories { get; }
 
 	#endregion
+
+	/// <summary>
+	/// Setup for a custom <see cref="IKeyedFusionCacheEntryOptionsProvider"/> registration to be used.
+	/// </summary>
+	CustomServiceRegistration<IKeyedFusionCacheEntryOptionsProvider> KeyDependentEntryOptionsProvider { get; set; }
 
 	/// <summary>
 	/// A custom post-setup action, that will be invoked just after the creation of the FusionCache instance, and before returning it to the caller.

--- a/src/ZiggyCreatures.FusionCache/IKeyedFusionCacheEntryOptionsProvider.cs
+++ b/src/ZiggyCreatures.FusionCache/IKeyedFusionCacheEntryOptionsProvider.cs
@@ -1,0 +1,15 @@
+﻿namespace ZiggyCreatures.Caching.Fusion
+{
+	/// <summary>
+	/// Common interface to provide <see cref="FusionCacheEntryOptions"/> based on a key.
+	/// </summary>
+	public interface IKeyedFusionCacheEntryOptionsProvider
+	{
+		/// <summary>
+		/// Gets the <see cref="FusionCacheEntryOptions"/> for the specified <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">The actual cache key.</param>
+		/// <returns><see cref="FusionCacheEntryOptions"/> for the specified <paramref name="key"/> or null if no match is found.</returns>
+		FusionCacheEntryOptions? GetEntryOptions(string key);
+	}
+}

--- a/src/ZiggyCreatures.FusionCache/Internals/Builder/CustomServiceRegistration.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Builder/CustomServiceRegistration.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace ZiggyCreatures.Caching.Fusion.Internals.Builder
+{
+	/// <summary>
+	/// Represents a custom service lookup configuration for a specific service type.
+	/// </summary>
+	/// <typeparam name="T">Type (normally, interface) of the service lookup.</typeparam>
+	public class CustomServiceRegistration<T>
+		where T : class
+	{
+		/// <summary>
+		/// Indicates if the builder should try find and use a service registered in the DI container.
+		/// </summary>
+		public bool UseRegistered { get; set; } = true;
+
+		/// <summary>
+		/// The keyed service key to use for DI lookup.
+		/// </summary>
+		public object? ServiceKey { get; set; }
+
+		/// <summary>
+		/// A specific service instance to be used.
+		/// </summary>
+		public T? Instance { get; set; }
+
+		/// <summary>
+		/// A factory that creates the service instance to be used.
+		/// </summary>
+		public Func<IServiceProvider, T>? InstanceFactory { get; set; }
+
+		/// <summary>
+		/// Throws an <see cref="InvalidOperationException"/> if an instance of the service is not specified or is not found in the DI container.
+		/// </summary>
+		public bool ThrowIfMissing { get; set; }
+	}
+}

--- a/src/ZiggyCreatures.FusionCache/KeyDependentFusionCacheEntryOptions.cs
+++ b/src/ZiggyCreatures.FusionCache/KeyDependentFusionCacheEntryOptions.cs
@@ -1,0 +1,33 @@
+﻿namespace ZiggyCreatures.Caching.Fusion
+{
+	/// <summary>
+	/// Represents all the options available for a single <see cref="IFusionCache"/> entry
+	/// for a cache key matching the template.
+	/// <br/><br/>
+	/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/Options.md"/>
+	/// </summary>
+	public sealed class KeyDependentFusionCacheEntryOptions
+	{
+		/// <summary>
+		/// Gets or sets the key template, for which the <see cref="FusionCacheEntryOptions"/> are to be used.
+		/// Any given cache key will be checked for a prefix matching this template.
+		/// <br/><br/>
+		/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/Options.md"/>
+		/// </summary>
+		public string KeyTemplate { get; set; }
+
+		/// <summary>
+		/// Gets or sets the <see cref="FusionCacheEntryOptions"/> to use when the cache key matches the key template.
+		/// <br/><br/>
+		/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/Options.md"/>
+		/// </summary>
+		public FusionCacheEntryOptions Options { get; set; }
+
+		public KeyDependentFusionCacheEntryOptions Duplicate() =>
+			new KeyDependentFusionCacheEntryOptions
+			{
+				KeyTemplate = KeyTemplate, 
+				Options = Options.Duplicate()
+			};
+	}
+}

--- a/src/ZiggyCreatures.FusionCache/KeyPrefixBasedEntryOptionsProvider.cs
+++ b/src/ZiggyCreatures.FusionCache/KeyPrefixBasedEntryOptionsProvider.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+
+namespace ZiggyCreatures.Caching.Fusion
+{
+	/// <summary>
+	/// A default implementation of <see cref="IKeyedFusionCacheEntryOptionsProvider"/> that provides <see cref="FusionCacheEntryOptions"/> based on the key prefix.
+	/// </summary>
+	public class KeyPrefixBasedEntryOptionsProvider : IKeyedFusionCacheEntryOptionsProvider
+	{
+		private readonly PrefixLookup<FusionCacheEntryOptions> _keyDependentCacheEntryOptionsLookup;
+
+		/// <summary>
+		/// Creates the <see cref="KeyPrefixBasedEntryOptionsProvider"/> instance.
+		/// </summary>
+		/// <param name="options">An instance of <see cref="FusionCacheOptions"/>.</param>
+		public KeyPrefixBasedEntryOptionsProvider(FusionCacheOptions options)
+		{
+			_keyDependentCacheEntryOptionsLookup = new PrefixLookup<FusionCacheEntryOptions>(
+				options.KeyDependentEntryOptions.ToDictionary(
+					entry => entry.KeyTemplate,
+					entry => entry.Options)!);
+		}
+
+		/// <inheritdoc />
+		public FusionCacheEntryOptions? GetEntryOptions(string key) => 
+			_keyDependentCacheEntryOptionsLookup.TryFind(key);
+	}
+}

--- a/src/ZiggyCreatures.FusionCache/MicrosoftHybridCache/FusionHybridCache.cs
+++ b/src/ZiggyCreatures.FusionCache/MicrosoftHybridCache/FusionHybridCache.cs
@@ -37,7 +37,7 @@ public sealed class FusionHybridCache
 		get { return _fusionCache; }
 	}
 
-	private FusionCacheEntryOptions? CreateFusionEntryOptions(HybridCacheEntryOptions? options, out bool allowFactory)
+	private FusionCacheEntryOptions? CreateFusionEntryOptions(string key, HybridCacheEntryOptions? options, out bool allowFactory)
 	{
 		allowFactory = true;
 
@@ -46,7 +46,7 @@ public sealed class FusionHybridCache
 			return NoEntryOptions;
 		}
 
-		var res = _fusionCache.CreateEntryOptions();
+		var res = _fusionCache.CreateEntryOptions(key);
 
 		if (options.Expiration is not null)
 		{
@@ -73,7 +73,7 @@ public sealed class FusionHybridCache
 	/// <inheritdoc/>
 	public override async ValueTask<T> GetOrCreateAsync<TState, T>(string key, TState state, Func<TState, CancellationToken, ValueTask<T>> factory, HybridCacheEntryOptions? options = null, IEnumerable<string>? tags = null, CancellationToken cancellationToken = default)
 	{
-		var feo = CreateFusionEntryOptions(options, out var allowFactory);
+		var feo = CreateFusionEntryOptions(key, options, out var allowFactory);
 
 		if (allowFactory == false)
 		{
@@ -111,7 +111,7 @@ public sealed class FusionHybridCache
 	/// <inheritdoc/>
 	public override ValueTask SetAsync<T>(string key, T value, HybridCacheEntryOptions? options = null, IEnumerable<string>? tags = null, CancellationToken cancellationToken = default)
 	{
-		return _fusionCache.SetAsync(key, value, CreateFusionEntryOptions(options, out _), tags, cancellationToken);
+		return _fusionCache.SetAsync(key, value, CreateFusionEntryOptions(key, options, out _), tags, cancellationToken);
 	}
 
 	private string GetDebuggerDisplay()

--- a/src/ZiggyCreatures.FusionCache/NullObjects/NullKeyedEntryOptionsProvider.cs
+++ b/src/ZiggyCreatures.FusionCache/NullObjects/NullKeyedEntryOptionsProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace ZiggyCreatures.Caching.Fusion.NullObjects
+{
+	/// <summary>
+	/// An implementation of <see cref="IKeyedFusionCacheEntryOptionsProvider"/> that implements the null object pattern, meaning that it does nothing, always returning default value of null.
+	/// </summary>
+	public class NullKeyedEntryOptionsProvider : IKeyedFusionCacheEntryOptionsProvider
+	{
+		/// <inheritdoc/>
+		public FusionCacheEntryOptions? GetEntryOptions(string key)
+		{
+			return null;
+		}
+	}
+}

--- a/src/ZiggyCreatures.FusionCache/PrefixLookup.cs
+++ b/src/ZiggyCreatures.FusionCache/PrefixLookup.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ZiggyCreatures.Caching.Fusion
+{
+	internal sealed class PrefixLookup<T>
+		where T : class
+	{
+		private readonly string[] _prefixes;
+		private readonly T?[] _values;
+
+		public PrefixLookup(IReadOnlyDictionary<string, T?> values)
+		{
+			if (values.Count == 0)
+			{
+				_prefixes = [];
+				_values = [];
+				return;
+			}
+
+			_prefixes = new string[values.Count];
+			_values = new T[values.Count];
+			var i = 0;
+
+			foreach(var item in values.OrderBy(pair => pair.Key))
+			{
+				_prefixes[i] = item.Key;
+				_values[i] = item.Value;
+				i++;
+			}
+		}
+
+		public T? TryFind(string key)
+		{
+			if (_prefixes.Length == 0)
+				return null;
+
+			var result = Array.BinarySearch(_prefixes, key);
+			if (result < 0)
+			{
+				result = (~result) - 1;
+			}
+			
+			return result >= 0 && key.StartsWith(_prefixes[result])
+				? _values[result]
+				: null;
+		}
+	}
+}

--- a/tests/ZiggyCreatures.FusionCache.Playground/Scenarios/LoggingScenario.cs
+++ b/tests/ZiggyCreatures.FusionCache.Playground/Scenarios/LoggingScenario.cs
@@ -193,7 +193,7 @@ public static class LoggingScenario
 		Console.WriteLine($"tmp5: {tmp5}");
 		Console.WriteLine();
 
-		await fusionCache.SetAsync("foo", 123, fusionCache.CreateEntryOptions(entry => entry.SetDurationSec(1).SetFailSafe(UseFailSafe)));
+		await fusionCache.SetAsync("foo", 123, fusionCache.CreateEntryOptions("foo", entry => entry.SetDurationSec(1).SetFailSafe(UseFailSafe)));
 		await Task.Delay(1_500);
 		Console.WriteLine();
 

--- a/tests/ZiggyCreatures.FusionCache.Playground/Scenarios/OpenTelemetryScenario.cs
+++ b/tests/ZiggyCreatures.FusionCache.Playground/Scenarios/OpenTelemetryScenario.cs
@@ -344,7 +344,7 @@ public static class OpenTelemetryScenario
 
 		using (var activity = Source.StartActivity("Top-Level Action (Set)"))
 		{
-			await fusionCache.SetAsync("foo", 123, fusionCache.CreateEntryOptions(entry => entry.SetDurationSec(1).SetFailSafe(UseFailSafe)));
+			await fusionCache.SetAsync("foo", 123, fusionCache.CreateEntryOptions("foo", entry => entry.SetDurationSec(1).SetFailSafe(UseFailSafe)));
 		}
 
 		await Task.Delay(1_500);

--- a/tests/ZiggyCreatures.FusionCache.Tests/GeneralTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/GeneralTests.cs
@@ -191,6 +191,11 @@ public class GeneralTests
 			CacheKeyPrefix = "Foo:",
 
 			DefaultEntryOptions = CreateEntryOptionsSample(),
+			KeyDependentEntryOptions =
+			[
+				new KeyDependentFusionCacheEntryOptions { KeyTemplate = "abc", Options = CreateEntryOptionsSample() },
+				new KeyDependentFusionCacheEntryOptions { KeyTemplate = "xyz", Options = CreateEntryOptionsSample() }
+			],
 
 			TagsDefaultEntryOptions = CreateEntryOptionsSample(),
 

--- a/tests/ZiggyCreatures.FusionCache.Tests/L1Tests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/L1Tests.cs
@@ -1808,6 +1808,42 @@ public class L1Tests
 	}
 
 	[Fact]
+	public async Task CanSkipMemoryCacheDueToKeyDependentOptionsAsync()
+	{
+		using var cache = new FusionCache(new FusionCacheOptions()
+		{
+			KeyDependentEntryOptions = [
+				new KeyDependentFusionCacheEntryOptions
+				{
+					KeyTemplate = "f",
+					Options = new FusionCacheEntryOptions().SetSkipMemoryCache()
+				}
+			]
+		});
+
+		await cache.SetAsync<int>("foo", 42);
+		var maybeFoo1 = await cache.TryGetAsync<int>("foo", opt => opt.SetSkipMemoryCache(false));
+		await cache.SetAsync<int>("foo", 42, opt => opt.SetSkipMemoryCache(false));
+		var maybeFoo2 = await cache.TryGetAsync<int>("foo");
+		var maybeFoo3 = await cache.TryGetAsync<int>("foo", opt => opt.SetSkipMemoryCache(false));
+		await cache.RemoveAsync("foo");
+		var maybeFoo4 = await cache.TryGetAsync<int>("foo", opt => opt.SetSkipMemoryCache(false));
+		await cache.RemoveAsync("foo", opt => opt.SetSkipMemoryCache(false));
+		var maybeFoo5 = await cache.TryGetAsync<int>("foo", opt => opt.SetSkipMemoryCache(false));
+
+		await cache.GetOrSetAsync<int>("bar", 42);
+		var maybeBar = await cache.TryGetAsync<int>("bar");
+
+		Assert.False(maybeFoo1.HasValue);
+		Assert.False(maybeFoo2.HasValue);
+		Assert.True(maybeFoo3.HasValue);
+		Assert.True(maybeFoo4.HasValue);
+		Assert.False(maybeFoo5.HasValue);
+
+		Assert.True(maybeBar.HasValue);
+	}
+
+	[Fact]
 	public void CanSkipMemoryCache()
 	{
 		using var cache = new FusionCache(new FusionCacheOptions());
@@ -1832,6 +1868,42 @@ public class L1Tests
 		Assert.False(maybeFoo5.HasValue);
 
 		Assert.False(maybeBar.HasValue);
+	}
+
+	[Fact]
+	public void CanSkipMemoryCacheDueToKeyDependentOptions()
+	{
+		using var cache = new FusionCache(new FusionCacheOptions()
+		{
+			KeyDependentEntryOptions = [
+				new KeyDependentFusionCacheEntryOptions
+				{
+					KeyTemplate = "f", 
+					Options = new FusionCacheEntryOptions().SetSkipMemoryCache()
+				}
+			]
+		});
+
+		cache.Set<int>("foo", 42);
+		var maybeFoo1 = cache.TryGet<int>("foo", opt => opt.SetSkipMemoryCache(false));
+		cache.Set<int>("foo", 42, opt => opt.SetSkipMemoryCache(false));
+		var maybeFoo2 = cache.TryGet<int>("foo");
+		var maybeFoo3 = cache.TryGet<int>("foo", opt => opt.SetSkipMemoryCache(false));
+		cache.Remove("foo");
+		var maybeFoo4 = cache.TryGet<int>("foo", opt => opt.SetSkipMemoryCache(false));
+		cache.Remove("foo", opt => opt.SetSkipMemoryCache(false));
+		var maybeFoo5 = cache.TryGet<int>("foo", opt => opt.SetSkipMemoryCache(false));
+
+		cache.GetOrSet<int>("bar", 42);
+		var maybeBar = cache.TryGet<int>("bar");
+
+		Assert.False(maybeFoo1.HasValue);
+		Assert.False(maybeFoo2.HasValue);
+		Assert.True(maybeFoo3.HasValue);
+		Assert.True(maybeFoo4.HasValue);
+		Assert.False(maybeFoo5.HasValue);
+
+		Assert.True(maybeBar.HasValue);
 	}
 
 	[Fact]

--- a/tests/ZiggyCreatures.FusionCache.Tests/PrefixLookupTest.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/PrefixLookupTest.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace FusionCacheTests;
+
+public class PrefixLookupTests
+{
+	[Fact]
+	public void TryFind_EmptyLookup_ReturnsDefault()
+	{
+		var prefixLookup = CreateLookup();
+
+		var result = prefixLookup.TryFind("someKey");
+
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void TryFind_SingleMatchingValue_ReturnsValue()
+	{
+		var prefixLookup = CreateLookup(
+			("someKey", "someValue"),
+			("otherKey", "otherValue"));
+
+		var result = prefixLookup.TryFind("someKey");
+
+		Assert.Equal("someValue", result);
+	}
+
+	[Fact]
+	public void TryFind_NoMatchingValue_ReturnsDefault()
+	{
+		var prefixLookup = CreateLookup(
+			("otherKey1", "otherValue1"),
+			("otherKey2", "otherValue2"));
+
+		var result1 = prefixLookup.TryFind("aKey"); // before min existing key
+		var result2 = prefixLookup.TryFind("someKey"); // after max existing key
+
+		Assert.Null(result1);
+		Assert.Null(result2);
+	}
+
+	[Fact]
+	public void TryFind_SingleMatchingPrefix_ReturnsValue()
+	{
+		var prefixLookup = CreateLookup(
+			("some", "someValue"),
+			("otherKey", "otherValue"));
+
+		var result = prefixLookup.TryFind("someKey-123");
+
+		Assert.Equal("someValue", result);
+	}
+
+	[Fact]
+	public void TryFind_MultipleMatchingPrefixes_ReturnsValueForLongestPrefix()
+	{
+		var prefixLookup = CreateLookup(
+			("s", "otherValue1"),
+			("some", "otherValue2"),
+			("someKey", "someValue"),
+			("someKey-2", "someOtherValue"));
+
+		var result = prefixLookup.TryFind("someKey-123");
+
+		Assert.Equal("someValue", result);
+	}
+
+	private static PrefixLookup<string> CreateLookup(params (string Prefix, string Value)[] values) =>
+		new(values.ToDictionary(
+			tuple => tuple.Prefix, 
+			tuple => tuple.Value)!);
+}

--- a/tests/ZiggyCreatures.FusionCache.Tests/Stuff/TestsUtils.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/Stuff/TestsUtils.cs
@@ -100,6 +100,11 @@ public static class TestsUtils
 		return typeof(FusionCache).GetField("_logger", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(cache) as ILogger;
 	}
 
+	public static IKeyedFusionCacheEntryOptionsProvider? GetKeyedEntryOptionsProvider(IFusionCache cache)
+	{
+		return typeof(FusionCache).GetField("_keyDependentEntryOptionsProvider", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(cache) as IKeyedFusionCacheEntryOptionsProvider;
+	}
+
 	public static IFusionCacheMemoryLocker? GetMemoryLocker(IFusionCache cache)
 	{
 		return typeof(FusionCache).GetField("_memoryLocker", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(cache) as IFusionCacheMemoryLocker;


### PR DESCRIPTION
Hi, I was not sure about the exact flow for the feature request/PR, so I decided to just create the PR directly. Let me know, if I need to create a corresponding issue and link it to this PR 😄 

## Problem

I want to be able to configure individual cache entry options for a given subset of keys (e.g., all keys, starting with "foo-") in a generic manner, that is, via standard IOptions mechanism, provided by Microsoft out of the box. This is beneficial for:
- storing all the configuration in one place
- overriding the configuration via common means (i.e., environment variables, appsettings.*.json files, AWS parameter store, etc.)
- cache API calls simplification: cache consumers don't need to know, how things are configured.

Currently, only the default entry options are exposed, which means I can only setup them for _all_ entries. However, if I want to setup entry options in a more granular manner, I need to resort to adjusting the code at the call site, providing modified options argument.

## Solution

Provide new **FusionCacheOptions.KeyDependentEntryOptions** property, that applies options per cache key template:
```
{
    "DefaultEntryOptions": { ... },
    "KeyDependentEntryOptions": [
        { "KeyTemplate": "foo-", "Options": { ... },
        { "KeyTemplate": "bar-", "Options": { ... },
    ]
}
```

Also, provide a public **IKeyedFusionCacheEntryOptionsProvider** interface, so that custom key lookup strategy can be used.

By default, the **KeyPrefixBasedEntryOptionsProvider** is used to select the corresponding options. It returns the entry options for the longest matching prefix for the given cache key. If no options are found, **DefaultEntryOptions** are returned.

On every cache operation that involves the cache key, get the entry options from the following sources, until one is found:
expliticly provided entry options -> key-dependent entry options -> default entry options

### Public API updates

1) **FusionCacheOptions** has a new KeyDependentEntryOptions (get/set) accessor.
2) **FusionCache** constructor now accepts an additional optional IKeyedFusionCacheEntryOptionsProvider parameter. This is the only place, that _might_ cause backward compatibility issues in some very specific circumstances, If this is not acceptable, then we can think of a different approach of setting the provider on cache (i.e. via a property).
Two built-in implementations for the interface are provided: **KeyPrefixBasedEntryOptionsProvider** and **NullKeyedEntryOptionsProvider**.
3) new overload `FusionCacheEntryOptions FusionCache.CreateEntryOptions(string key, Action<FusionCacheEntryOptions>? setupAction = null, TimeSpan? duration = null)` has been added as an addition to the existing one, that doesn't accept the key. I'm not sure if it makes sense to mark the existing one as Obsolete, since it is no longer used. I kept it as is for now.
4) **IFusionCacheBuilder** now has a new `IFusionCacheBuilder WithKeyDependentEntryOptionsProvider(this IFusionCacheBuilder builder, Action<CustomServiceRegistration<IKeyedFusionCacheEntryOptionsProvider>> config)` extension method to setup custom IKeyedFusionCacheEntryOptionsProvider provider.

### Implementation details and limitations

The current implementation of **KeyPrefixBasedEntryOptionsProvider** is instantiated upon **FusionCache** creation, which means later updates to the KeyPrefixBasedEntryOptions members will have only limited effect. That is, changes to the entry options themselves will be applied, however it is not possible to add or remove mappings, or adjust key templates for mappings after cache creation.

Default **KeyPrefixBasedEntryOptionsProvider** does not support multiple configurations for the same prefix: the internal .ToDictionary() call will throw on multiple entries with the same KeyTemplate. This is done on purpose, to avoid unexpected behavior and hard-to-track bugs later at runtime.

Current prefix search algorithm is a simple binary search among the pre-sorted array of prefixes. Assuming the amount of mappings will stay reasonably small, it shouldn't give too much of an overhead. Otherwise a better data structure, e.g., prefix tree can be assumed. Also, when key-dependent options are not set (that is the case for all existing setups), the only overhead is an additional length + null check, which should be negligible.

IMPORTANT: keys are considered exactly as they are passed in to the public APIs, that is _before_ applying the CacheKeyPrefix adjustment. The reason for this is that CacheKeyPrefix is set up only once for the entire cache, so it is expected to stay the same for all keys.

---

PS The PR is pretty big, sorry for that. Luckily, the majority of changes are to the XML comments 😸 
Also, the project itself is already very nicely structured, so incorporating the options selection fits in perfectly in the existing APIs, without affecting any lower-level caching logic.

And thank you once again for the awesome library! 🚀 