### PR TITLE
Fix deserialization issue in FusionCache

### DIFF
--- a/src/ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson/FusionCacheNewtonsoftJsonSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson/FusionCacheNewtonsoftJsonSerializer.cs
@@ -1,9 +1,10 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 using ZiggyCreatures.Caching.Fusion.Internals;
 
@@ -77,7 +78,14 @@ public class FusionCacheNewtonsoftJsonSerializer
 		using var reader = new StreamReader(stream, _encoding);
 		using var jsonReader = new JsonTextReader(reader);
 		jsonReader.ArrayPool = JsonArrayPool.Shared;
-		return _jsonSerializer.Deserialize<T>(jsonReader);
+		var deserializedObject = _jsonSerializer.Deserialize<T>(jsonReader);
+
+		if (deserializedObject is JToken jToken)
+		{
+			return jToken.ToObject<T>();
+		}
+
+		return deserializedObject;
 	}
 
 	/// <inheritdoc />

--- a/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/FusionCacheSystemTextJsonSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/FusionCacheSystemTextJsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -50,7 +50,14 @@ public class FusionCacheSystemTextJsonSerializer
 	/// <inheritdoc />
 	public T? Deserialize<T>(byte[] data)
 	{
-		return JsonSerializer.Deserialize<T>(data, _serializerOptions);
+		var deserializedObject = JsonSerializer.Deserialize<T>(data, _serializerOptions);
+
+		if (deserializedObject is JsonElement jsonElement)
+		{
+			return JsonSerializer.Deserialize<T>(jsonElement.GetRawText(), _serializerOptions);
+		}
+
+		return deserializedObject;
 	}
 
 	/// <inheritdoc />

--- a/src/ZiggyCreatures.FusionCache/Internals/Memory/FusionCacheMemoryEntry.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Memory/FusionCacheMemoryEntry.cs
@@ -1,7 +1,9 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using ZiggyCreatures.Caching.Fusion.Internals.Distributed;
 using ZiggyCreatures.Caching.Fusion.Serialization;
+using System.Text.Json;
+using Newtonsoft.Json.Linq;
 
 namespace ZiggyCreatures.Caching.Fusion.Internals.Memory;
 
@@ -65,6 +67,16 @@ internal sealed class FusionCacheMemoryEntry<TValue>
 
 	public TValue1 GetValue<TValue1>()
 	{
+		if (Value is JsonElement jsonElement)
+		{
+			// Use the appropriate deserializer to convert JsonElement to TValue1
+			return JsonSerializer.Deserialize<TValue1>(jsonElement.GetRawText())!;
+		}
+		else if (Value is JToken jToken)
+		{
+			// Use the appropriate deserializer to convert JToken to TValue1
+			return jToken.ToObject<TValue1>()!;
+		}
 		return (TValue1)Value!;
 	}
 

--- a/tests/ZiggyCreatures.FusionCache.Tests/SerializationTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/SerializationTests.cs
@@ -1,5 +1,8 @@
-﻿using FusionCacheTests.Stuff;
+using FusionCacheTests.Stuff;
 using Xunit.Abstractions;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion.Serialization.NewtonsoftJson;
+using ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson;
 
 namespace FusionCacheTests;
 
@@ -24,4 +27,28 @@ public partial class SerializationTests
 	}
 
 	private const string SampleString = "Supercalifragilisticexpialidocious";
+
+	[Fact]
+	public void DeserializeWorksCorrectlyAfterAppRestart_NewtonsoftJson()
+	{
+		var serializer = new FusionCacheNewtonsoftJsonSerializer();
+		var jsonData = "{\"Name\":\"John\",\"Age\":30}";
+		var data = System.Text.Encoding.UTF8.GetBytes(jsonData);
+		var deserializedObject = serializer.Deserialize<ComplexType>(data);
+		Assert.NotNull(deserializedObject);
+		Assert.Equal("John", deserializedObject.Name);
+		Assert.Equal(30, deserializedObject.Age);
+	}
+
+	[Fact]
+	public void DeserializeWorksCorrectlyAfterAppRestart_SystemTextJson()
+	{
+		var serializer = new FusionCacheSystemTextJsonSerializer();
+		var jsonData = "{\"Name\":\"John\",\"Age\":30}";
+		var data = System.Text.Encoding.UTF8.GetBytes(jsonData);
+		var deserializedObject = serializer.Deserialize<ComplexType>(data);
+		Assert.NotNull(deserializedObject);
+		Assert.Equal("John", deserializedObject.Name);
+		Assert.Equal(30, deserializedObject.Age);
+	}
 }


### PR DESCRIPTION
Related to #386

Fix deserialization issue when retrieving data from L2 Cache after an app restart.

* **FusionCacheMemoryEntry.cs**
  - Update `GetValue<TValue1>` method to handle deserialization correctly for `JsonElement` and `JToken`.
  - Add checks to determine if the value is of type `JsonElement` or `JToken`.
  - Use the appropriate deserializer to convert `JsonElement` or `JToken` to `TValue1`.

* **FusionCacheNewtonsoftJsonSerializer.cs**
  - Update `Deserialize<T>` method to handle conversion correctly for `JToken`.
  - Add a check to determine if the data is of type `JToken`.
  - Use the appropriate deserializer to convert `JToken` to `T`.

* **FusionCacheSystemTextJsonSerializer.cs**
  - Update `Deserialize<T>` method to handle conversion correctly for `JsonElement`.
  - Add a check to determine if the data is of type `JsonElement`.
  - Use the appropriate deserializer to convert `JsonElement` to `T`.

* **SerializationTests.cs**
  - Add tests to ensure deserialization works correctly after an app restart.
  - Create a test case for `FusionCacheNewtonsoftJsonSerializer`.
  - Create a test case for `FusionCacheSystemTextJsonSerializer`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ZiggyCreatures/FusionCache/pull/387?shareId=4d7e29c7-a119-47b6-b8ae-8fef060520f9).