### PR TITLE
remove redundant dispose code

### DIFF
--- a/src/ZiggyCreatures.FusionCache.Locking.AsyncKeyed/AsyncKeyedMemoryLocker.cs
+++ b/src/ZiggyCreatures.FusionCache.Locking.AsyncKeyed/AsyncKeyedMemoryLocker.cs
@@ -52,23 +52,17 @@ public sealed class AsyncKeyedMemoryLocker
 
 	// IDISPOSABLE
 	private bool disposedValue;
-	private void Dispose(bool disposing)
-	{
-		if (!disposedValue)
-		{
-			if (disposing)
-			{
-				_locker?.Dispose();
-			}
-
-			disposedValue = true;
-		}
-	}
 
 	/// <inheritdoc/>
 	public void Dispose()
 	{
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
+		if (disposedValue)
+		{
+			return;
+		}
+
+		_locker?.Dispose();
+
+		disposedValue = true;
 	}
 }

--- a/src/ZiggyCreatures.FusionCache.Locking.AsyncKeyed/StripedAsyncKeyedMemoryLocker.cs
+++ b/src/ZiggyCreatures.FusionCache.Locking.AsyncKeyed/StripedAsyncKeyedMemoryLocker.cs
@@ -49,25 +49,8 @@ public sealed class StripedAsyncKeyedMemoryLocker
 		}
 	}
 
-	// IDISPOSABLE
-	private bool _disposedValue;
-	private void Dispose(bool disposing)
-	{
-		if (!_disposedValue)
-		{
-			if (disposing)
-			{
-				// EMPTY
-			}
-
-			_disposedValue = true;
-		}
-	}
-
 	/// <inheritdoc/>
 	public void Dispose()
 	{
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
 	}
 }

--- a/src/ZiggyCreatures.FusionCache/FusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache.cs
@@ -1154,42 +1154,30 @@ public sealed partial class FusionCache
 	/// <summary>
 	/// Release all resources managed by FusionCache.
 	/// </summary>
-	/// <param name="disposing">Indicates if the disposing is happening.</param>
-	private void Dispose(bool disposing)
-	//protected virtual void Dispose(bool disposing)
-	{
-		if (!_disposedValue)
-		{
-			if (disposing)
-			{
-				RemoveAllPlugins();
-				RemoveBackplane();
-				RemoveDistributedCache();
-
-				_autoRecovery?.Dispose();
-				_autoRecovery = null;
-
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-				_memoryLocker.Dispose();
-				_memoryLocker = null;
-
-				_mca.Dispose();
-				_mca = null;
-
-				_events = null;
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
-			}
-
-			_disposedValue = true;
-		}
-	}
-
-	/// <summary>
-	/// Release all resources managed by FusionCache.
-	/// </summary>
 	public void Dispose()
 	{
-		Dispose(true);
-		GC.SuppressFinalize(this);
+		if (_disposedValue)
+		{
+			return;
+		}
+
+		RemoveAllPlugins();
+		RemoveBackplane();
+		RemoveDistributedCache();
+
+		_autoRecovery?.Dispose();
+		_autoRecovery = null;
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		_memoryLocker.Dispose();
+		_memoryLocker = null;
+
+		_mca.Dispose();
+		_mca = null;
+
+		_events = null;
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
+		_disposedValue = true;
 	}
 }

--- a/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolBufferWriter.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/ArrayPoolBufferWriter.cs
@@ -100,28 +100,15 @@ public sealed class ArrayPoolBufferWriter : IBufferWriter<byte>, IDisposable
 		throw new InvalidOperationException("Cannot advance past the end of the buffer.");
 	}
 
-	/// <summary>
-	/// Returns the buffer to the pool.
-	/// </summary>
-	/// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-	private void Dispose(bool disposing)
-	{
-		if (!disposedValue)
-		{
-			if (disposing)
-			{
-				_arrayPool.Return(_buffer);
-			}
-
-			disposedValue = true;
-		}
-	}
-
 	/// <inheritdoc/>
 	public void Dispose()
 	{
-		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
+		if (disposedValue)
+		{
+			return;
+		}
+
+		_arrayPool.Return(_buffer);
+		disposedValue = true;
 	}
 }

--- a/src/ZiggyCreatures.FusionCache/Internals/AutoRecovery/AutoRecoveryService.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/AutoRecovery/AutoRecoveryService.cs
@@ -652,25 +652,19 @@ internal sealed class AutoRecoveryService
 
 	// IDISPOSABLE
 	private bool _disposedValue;
-	private void Dispose(bool disposing)
-	{
-		if (!_disposedValue)
-		{
-			if (disposing)
-			{
-				_queue.Clear();
-				_cts?.Cancel();
-				_cts?.Dispose();
-				_cts = null;
-			}
-
-			_disposedValue = true;
-		}
-	}
 
 	public void Dispose()
 	{
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
+		if (_disposedValue)
+		{
+			return;
+		}
+
+		_queue.Clear();
+		_cts?.Cancel();
+		_cts?.Dispose();
+		_cts = null;
+
+		_disposedValue = true;
 	}
 }

--- a/src/ZiggyCreatures.FusionCache/Locking/ExperimentalMemoryLocker.cs
+++ b/src/ZiggyCreatures.FusionCache/Locking/ExperimentalMemoryLocker.cs
@@ -116,26 +116,20 @@ internal sealed class ExperimentalMemoryLocker
 
 	// IDISPOSABLE
 	private bool _disposedValue;
-	private void Dispose(bool disposing)
-	{
-		if (!_disposedValue)
-		{
-			if (disposing)
-			{
-				_tcsCache.Clear();
-			}
-
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-			_tcsCache = null;
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
-			_disposedValue = true;
-		}
-	}
 
 	/// <inheritdoc/>
 	public void Dispose()
 	{
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
+		if (_disposedValue)
+		{
+			return;
+		}
+
+		_tcsCache.Clear();
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		_tcsCache = null;
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+		_disposedValue = true;
 	}
 }

--- a/src/ZiggyCreatures.FusionCache/Locking/ProbabilisticMemoryLocker.cs
+++ b/src/ZiggyCreatures.FusionCache/Locking/ProbabilisticMemoryLocker.cs
@@ -75,32 +75,26 @@ internal sealed class ProbabilisticMemoryLocker
 
 	// IDISPOSABLE
 	private bool _disposedValue;
-	private void Dispose(bool disposing)
-	{
-		if (!_disposedValue)
-		{
-			if (disposing)
-			{
-				if (_pool is not null)
-				{
-					foreach (var semaphore in _pool)
-					{
-						semaphore.Dispose();
-					}
-				}
-			}
-
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-			_pool = null;
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
-			_disposedValue = true;
-		}
-	}
 
 	/// <inheritdoc/>
 	public void Dispose()
 	{
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
+		if (_disposedValue)
+		{
+			return;
+		}
+
+		if (_pool is not null)
+		{
+			foreach (var semaphore in _pool)
+			{
+				semaphore.Dispose();
+			}
+		}
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		_pool = null;
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+		_disposedValue = true;
 	}
 }

--- a/src/ZiggyCreatures.FusionCache/Locking/StandardMemoryLocker.cs
+++ b/src/ZiggyCreatures.FusionCache/Locking/StandardMemoryLocker.cs
@@ -120,27 +120,21 @@ internal sealed class StandardMemoryLocker
 
 	// IDISPOSABLE
 	private bool _disposedValue;
-	private void Dispose(bool disposing)
-	{
-		if (!_disposedValue)
-		{
-			if (disposing)
-			{
-				_lockCache.Compact(1.0);
-				_lockCache.Dispose();
-			}
-
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-			_lockCache = null;
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
-			_disposedValue = true;
-		}
-	}
 
 	/// <inheritdoc/>
 	public void Dispose()
 	{
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
+		if (_disposedValue)
+		{
+			return;
+		}
+
+		_lockCache.Compact(1.0);
+		_lockCache.Dispose();
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		_lockCache = null;
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+		_disposedValue = true;
 	}
 }


### PR DESCRIPTION
the `Dispose(disposing: true);` + `GC.SuppressFinalize(this);` pattern is only required when cleaning up un-managed resources