### PR TITLE
 add cache entry metadata to event args

### DIFF
--- a/src/ZiggyCreatures.FusionCache/Events/FusionCacheCommonEventsHub.cs
+++ b/src/ZiggyCreatures.FusionCache/Events/FusionCacheCommonEventsHub.cs
@@ -36,6 +36,7 @@ public abstract class FusionCacheCommonEventsHub
 	/// <summary>
 	/// The event for a cache set.
 	/// </summary>
+	/// <remarks>The event args has not been strongly typed to avoid breaking changes but it can be cast as an instance of <see cref="FusionCacheEntrySetEventArgs"/> when subscribed to.</remarks>
 	public event EventHandler<FusionCacheEntryEventArgs>? Set;
 
 	/// <summary>
@@ -43,13 +44,13 @@ public abstract class FusionCacheCommonEventsHub
 	/// </summary>
 	public event EventHandler<FusionCacheEntryEventArgs>? Remove;
 
-	internal virtual void OnHit(string operationId, string key, bool isStale, Activity? activity)
+	internal virtual void OnHit(string operationId, string key, bool isStale, Activity? activity, FusionCacheEntryMetadata? metadata)
 	{
 		// ACTIVITY
 		activity?.AddTag(Tags.Names.Hit, true);
 		activity?.AddTag(Tags.Names.Stale, isStale);
 
-		Hit?.SafeExecute(operationId, key, _cache, new FusionCacheEntryHitEventArgs(key, isStale), nameof(Hit), _logger, _errorsLogLevel, _syncExecution);
+		Hit?.SafeExecute(operationId, key, _cache, new FusionCacheEntryHitEventArgs(key, isStale, metadata), nameof(Hit), _logger, _errorsLogLevel, _syncExecution);
 	}
 
 	internal virtual void OnMiss(string operationId, string key, Activity? activity)
@@ -60,9 +61,9 @@ public abstract class FusionCacheCommonEventsHub
 		Miss?.SafeExecute(operationId, key, _cache, new FusionCacheEntryEventArgs(key), nameof(Miss), _logger, _errorsLogLevel, _syncExecution);
 	}
 
-	internal virtual void OnSet(string operationId, string key)
+	internal virtual void OnSet(string operationId, string key, FusionCacheEntryMetadata? metadata)
 	{
-		Set?.SafeExecute(operationId, key, _cache, new FusionCacheEntryEventArgs(key), nameof(Set), _logger, _errorsLogLevel, _syncExecution);
+		Set?.SafeExecute(operationId, key, _cache, new FusionCacheEntrySetEventArgs(key, metadata), nameof(Set), _logger, _errorsLogLevel, _syncExecution);
 	}
 
 	internal virtual void OnRemove(string operationId, string key)

--- a/src/ZiggyCreatures.FusionCache/Events/FusionCacheDistributedEventsHub.cs
+++ b/src/ZiggyCreatures.FusionCache/Events/FusionCacheDistributedEventsHub.cs
@@ -61,12 +61,12 @@ public sealed class FusionCacheDistributedEventsHub
 		DeserializationError?.SafeExecute(operationId, key, _cache, new FusionCacheEntryEventArgs(key ?? string.Empty), nameof(DeserializationError), _logger, _errorsLogLevel, _syncExecution);
 	}
 
-	internal override void OnHit(string operationId, string key, bool isStale, Activity? activity)
+	internal override void OnHit(string operationId, string key, bool isStale, Activity? activity, FusionCacheEntryMetadata? metadata)
 	{
 		// METRIC
 		Metrics.CounterDistributedHit.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId, new KeyValuePair<string, object?>(Tags.Names.Stale, isStale));
 
-		base.OnHit(operationId, key, isStale, activity);
+		base.OnHit(operationId, key, isStale, activity, metadata);
 	}
 
 	internal override void OnMiss(string operationId, string key, Activity? activity)
@@ -77,12 +77,12 @@ public sealed class FusionCacheDistributedEventsHub
 		base.OnMiss(operationId, key, activity);
 	}
 
-	internal override void OnSet(string operationId, string key)
+	internal override void OnSet(string operationId, string key, FusionCacheEntryMetadata? metadata)
 	{
 		// METRIC
 		Metrics.CounterDistributedSet.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId);
 
-		base.OnSet(operationId, key);
+		base.OnSet(operationId, key, metadata);
 	}
 
 	internal override void OnRemove(string operationId, string key)

--- a/src/ZiggyCreatures.FusionCache/Events/FusionCacheEntryEvictionEventArgs.cs
+++ b/src/ZiggyCreatures.FusionCache/Events/FusionCacheEntryEvictionEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
+using ZiggyCreatures.Caching.Fusion.Internals;
 
 namespace ZiggyCreatures.Caching.Fusion.Events;
 
@@ -15,10 +16,23 @@ public class FusionCacheEntryEvictionEventArgs
 	/// <param name="reason">The reason for the eviction.</param>
 	/// <param name="value">The value being evicted from the cache.</param>
 	public FusionCacheEntryEvictionEventArgs(string key, EvictionReason reason, object? value)
+		: this(key, reason, value, null)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FusionCacheEntryEvictionEventArgs"/> class.
+	/// </summary>
+	/// <param name="key">The cache key related to the event.</param>
+	/// <param name="reason">The reason for the eviction.</param>
+	/// <param name="value">The value being evicted from the cache.</param>
+	/// <param name="metadata">The metadata related to the cache entry evicted (if any).</param>
+	public FusionCacheEntryEvictionEventArgs(string key, EvictionReason reason, object? value, FusionCacheEntryMetadata? metadata)
 		: base(key)
 	{
 		Reason = reason;
 		Value = value;
+		Metadata = metadata;
 	}
 
 	/// <summary>
@@ -30,4 +44,9 @@ public class FusionCacheEntryEvictionEventArgs
 	/// The value being evicted from the cache.
 	/// </summary>
 	public object? Value { get; }
+
+	/// <summary>
+	/// The metadata related to the cache entry evicted (if any).
+	/// </summary>
+	public FusionCacheEntryMetadata? Metadata { get; }
 }

--- a/src/ZiggyCreatures.FusionCache/Events/FusionCacheEntryExpirationEventArgs.cs
+++ b/src/ZiggyCreatures.FusionCache/Events/FusionCacheEntryExpirationEventArgs.cs
@@ -1,0 +1,25 @@
+﻿using ZiggyCreatures.Caching.Fusion.Internals;
+
+namespace ZiggyCreatures.Caching.Fusion.Events;
+
+/// <summary>
+/// The specific <see cref="EventArgs"/> object for events related to cache entries' expirations.
+/// </summary>
+public class FusionCacheEntryExpirationEventArgs : FusionCacheEntryEventArgs
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FusionCacheEntryExpirationEventArgs" /> class.
+	/// </summary>
+	/// <param name="key">The cache key related to the event.</param>
+	/// <param name="metadata">The metadata related to the cache entry expired (if any).</param>
+	public FusionCacheEntryExpirationEventArgs(string key, FusionCacheEntryMetadata? metadata)
+		: base(key)
+	{
+		Metadata = metadata;
+	}
+
+	/// <summary>
+	/// The metadata related to the cache entry expired (if any).
+	/// </summary>
+	public FusionCacheEntryMetadata? Metadata { get; }
+}

--- a/src/ZiggyCreatures.FusionCache/Events/FusionCacheEntryHitEventArgs.cs
+++ b/src/ZiggyCreatures.FusionCache/Events/FusionCacheEntryHitEventArgs.cs
@@ -1,4 +1,6 @@
-﻿namespace ZiggyCreatures.Caching.Fusion.Events;
+﻿using ZiggyCreatures.Caching.Fusion.Internals;
+
+namespace ZiggyCreatures.Caching.Fusion.Events;
 
 /// <summary>
 /// The specific <see cref="EventArgs"/> object for events related to cache entries' hits (eg: with a cache key and a stale flag).
@@ -11,13 +13,30 @@ public class FusionCacheEntryHitEventArgs : FusionCacheEntryEventArgs
 	/// <param name="key">The cache key related to the event.</param>
 	/// <param name="isStale">A flag that indicates if the cache hit was for a fresh or stale entry.</param>
 	public FusionCacheEntryHitEventArgs(string key, bool isStale)
+		: this(key, isStale, null)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FusionCacheEntryHitEventArgs" /> class.
+	/// </summary>
+	/// <param name="key">The cache key related to the event.</param>
+	/// <param name="isStale">A flag that indicates if the cache hit was for a fresh or stale entry.</param>
+	/// <param name="metadata">The metadata related to the cache entry hit (if any).</param>
+	public FusionCacheEntryHitEventArgs(string key, bool isStale, FusionCacheEntryMetadata? metadata)
 		: base(key)
 	{
 		IsStale = isStale;
+		Metadata = metadata;
 	}
 
 	/// <summary>
 	/// A flag that indicates if the cache hit was for a fresh or stale entry.
 	/// </summary>
 	public bool IsStale { get; }
+
+	/// <summary>
+	/// The metadata related to the cache entry hit (if any).
+	/// </summary>
+	public FusionCacheEntryMetadata? Metadata { get; }
 }

--- a/src/ZiggyCreatures.FusionCache/Events/FusionCacheEntrySetEventArgs.cs
+++ b/src/ZiggyCreatures.FusionCache/Events/FusionCacheEntrySetEventArgs.cs
@@ -1,0 +1,25 @@
+﻿using ZiggyCreatures.Caching.Fusion.Internals;
+
+namespace ZiggyCreatures.Caching.Fusion.Events;
+
+/// <summary>
+/// The specific <see cref="EventArgs"/> object for events related to cache entries' set.
+/// </summary>
+public class FusionCacheEntrySetEventArgs : FusionCacheEntryEventArgs
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FusionCacheEntrySetEventArgs" /> class.
+	/// </summary>
+	/// <param name="key">The cache key related to the event.</param>
+	/// <param name="metadata">The metadata related to the cache entry set (if any).</param>
+	public FusionCacheEntrySetEventArgs(string key, FusionCacheEntryMetadata? metadata)
+		: base(key)
+	{
+		Metadata = metadata;
+	}
+
+	/// <summary>
+	/// The metadata related to the cache entry set (if any).
+	/// </summary>
+	public FusionCacheEntryMetadata? Metadata { get; }
+}

--- a/src/ZiggyCreatures.FusionCache/Events/FusionCacheEventsHub.cs
+++ b/src/ZiggyCreatures.FusionCache/Events/FusionCacheEventsHub.cs
@@ -90,7 +90,7 @@ public sealed class FusionCacheEventsHub
 	/// </summary>
 	public event EventHandler<EventArgs>? Clear;
 
-	internal void OnFailSafeActivate(string operationId, string key)
+	internal void OnFailSafeActivate(string operationId, string key, FusionCacheEntryMetadata? metadata)
 	{
 		// METRIC
 		Metrics.CounterFailSafeActivate.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId);
@@ -114,7 +114,7 @@ public sealed class FusionCacheEventsHub
 		FactoryError?.SafeExecute(operationId, key, _cache, new FusionCacheEntryEventArgs(key), nameof(FactoryError), _logger, _errorsLogLevel, _syncExecution);
 	}
 
-	internal void OnFactorySuccess(string operationId, string key)
+	internal void OnFactorySuccess(string operationId, string key, FusionCacheEntryMetadata? metadata)
 	{
 		// METRIC
 		Metrics.CounterFactorySuccess.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId, new KeyValuePair<string, object?>(Tags.Names.OperationBackground, false));
@@ -130,7 +130,7 @@ public sealed class FusionCacheEventsHub
 		BackgroundFactoryError?.SafeExecute(operationId, key, _cache, new FusionCacheEntryEventArgs(key), nameof(BackgroundFactoryError), _logger, _errorsLogLevel, _syncExecution);
 	}
 
-	internal void OnBackgroundFactorySuccess(string operationId, string key)
+	internal void OnBackgroundFactorySuccess(string operationId, string key, FusionCacheEntryMetadata? metadata)
 	{
 		// METRIC
 		Metrics.CounterFactorySuccess.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId, new KeyValuePair<string, object?>(Tags.Names.OperationBackground, true));
@@ -138,7 +138,7 @@ public sealed class FusionCacheEventsHub
 		BackgroundFactorySuccess?.SafeExecute(operationId, key, _cache, new FusionCacheEntryEventArgs(key), nameof(BackgroundFactorySuccess), _logger, _errorsLogLevel, _syncExecution);
 	}
 
-	internal void OnEagerRefresh(string operationId, string key)
+	internal void OnEagerRefresh(string operationId, string key, FusionCacheEntryMetadata? metadata)
 	{
 		// METRIC
 		Metrics.CounterEagerRefresh.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId);
@@ -178,12 +178,12 @@ public sealed class FusionCacheEventsHub
 
 	// OVERRIDES
 
-	internal override void OnHit(string operationId, string key, bool isStale, Activity? activity)
+	internal override void OnHit(string operationId, string key, bool isStale, Activity? activity, FusionCacheEntryMetadata? metadata)
 	{
 		// METRIC
 		Metrics.CounterHit.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId, new KeyValuePair<string, object?>(Tags.Names.Stale, isStale));
 
-		base.OnHit(operationId, key, isStale, activity);
+		base.OnHit(operationId, key, isStale, activity, metadata);
 	}
 
 	internal override void OnMiss(string operationId, string key, Activity? activity)
@@ -194,12 +194,12 @@ public sealed class FusionCacheEventsHub
 		base.OnMiss(operationId, key, activity);
 	}
 
-	internal override void OnSet(string operationId, string key)
+	internal override void OnSet(string operationId, string key, FusionCacheEntryMetadata? metadata)
 	{
 		// METRIC
 		Metrics.CounterSet.Maybe()?.AddWithCommonTags(1, _cache.CacheName, _cache.InstanceId);
 
-		base.OnSet(operationId, key);
+		base.OnSet(operationId, key, metadata);
 	}
 
 	internal override void OnRemove(string operationId, string key)

--- a/src/ZiggyCreatures.FusionCache/FusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache.cs
@@ -398,7 +398,7 @@ public sealed partial class FusionCache
 		if (entry is not null)
 		{
 			// EVENT
-			_events.OnFailSafeActivate(operationId, key);
+			_events.OnFailSafeActivate(operationId, key, entry.Metadata);
 
 			return entry;
 		}
@@ -536,8 +536,8 @@ public sealed partial class FusionCache
 					}
 
 					// EVENT
-					_events.OnBackgroundFactorySuccess(operationId, key);
-					_events.OnSet(operationId, key);
+					_events.OnBackgroundFactorySuccess(operationId, key, lateEntry.Metadata);
+					_events.OnSet(operationId, key, lateEntry.Metadata);
 				}
 			}
 			finally

--- a/src/ZiggyCreatures.FusionCache/FusionCacheEntryOptions.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheEntryOptions.cs
@@ -970,7 +970,8 @@ public sealed class FusionCacheEntryOptions
 			res.RegisterPostEvictionCallback(
 				(key, entry, reason, state) =>
 				{
-					((FusionCacheMemoryEventsHub?)state)?.OnEviction(string.Empty, key.ToString() ?? "", reason, ((IFusionCacheMemoryEntry?)entry)?.Value);
+					var memoryEntry = (IFusionCacheMemoryEntry?)entry;
+					((FusionCacheMemoryEventsHub?)state)?.OnEviction(string.Empty, key.ToString() ?? "", reason, memoryEntry?.Value, memoryEntry?.Metadata);
 				},
 				events
 			);

--- a/src/ZiggyCreatures.FusionCache/FusionCache_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache_Sync.cs
@@ -15,7 +15,7 @@ public partial class FusionCache
 	private void ExecuteEagerRefreshWithSyncFactory<TValue>(string operationId, string key, string originalKey, string[]? tags, Func<FusionCacheFactoryExecutionContext<TValue>, CancellationToken, TValue> factory, FusionCacheEntryOptions options, IFusionCacheMemoryEntry memoryEntry, object memoryLockObj)
 	{
 		// EVENT
-		_events.OnEagerRefresh(operationId, key);
+		_events.OnEagerRefresh(operationId, key, memoryEntry.Metadata);
 
 		_ = Task.Run(() =>
 		{
@@ -132,7 +132,7 @@ public partial class FusionCache
 				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): using memory entry", CacheName, InstanceId, operationId, key);
 
 			// EVENT
-			_events.OnHit(operationId, key, memoryEntryIsValid == false || memoryEntry!.IsStale(), activity);
+			_events.OnHit(operationId, key, memoryEntry!.IsStale(), activity, memoryEntry!.Metadata);
 
 			return memoryEntry;
 		}
@@ -155,7 +155,7 @@ public partial class FusionCache
 				// --> USE IT (WITHOUT SAVING IT, SINCE THE ALREADY RUNNING FACTORY WILL DO IT ANYWAY)
 
 				// EVENT
-				_events.OnHit(operationId, key, memoryEntryIsValid == false || memoryEntry.IsStale(), activity);
+				_events.OnHit(operationId, key, true, activity, memoryEntry.Metadata);
 
 				return memoryEntry;
 			}
@@ -178,7 +178,7 @@ public partial class FusionCache
 					_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): using memory entry", CacheName, InstanceId, operationId, key);
 
 				// EVENT
-				_events.OnHit(operationId, key, memoryEntryIsValid == false || memoryEntry!.IsStale(), activity);
+				_events.OnHit(operationId, key, memoryEntryIsValid == false || memoryEntry!.IsStale(), activity, memoryEntry!.Metadata);
 
 				return memoryEntry;
 			}
@@ -283,7 +283,7 @@ public partial class FusionCache
 							entry = FusionCacheMemoryEntry<TValue>.CreateFromOptions(value, GetSerializedValueFromValue(operationId, key, value, options), null, ctx.Tags, options, isStale, ctx.LastModified?.UtcTicks, ctx.ETag);
 
 							// EVENTS
-							_events.OnFactorySuccess(operationId, key);
+							_events.OnFactorySuccess(operationId, key, entry.Metadata);
 						}
 					}
 					catch (OperationCanceledException exc)
@@ -344,12 +344,12 @@ public partial class FusionCache
 
 			// EVENT
 			_events.OnMiss(operationId, key, activity);
-			_events.OnSet(operationId, key);
+			_events.OnSet(operationId, key, entry?.Metadata);
 		}
 		else if (entry is not null)
 		{
 			// EVENT
-			_events.OnHit(operationId, key, isStale || entry.IsStale(), activity);
+			_events.OnHit(operationId, key, isStale || entry.IsStale(), activity, entry.Metadata);
 		}
 		else
 		{
@@ -493,7 +493,7 @@ public partial class FusionCache
 				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): using memory entry", CacheName, InstanceId, operationId, key);
 
 			// EVENT
-			_events.OnHit(operationId, key, memoryEntry!.IsStale(), activity);
+			_events.OnHit(operationId, key, memoryEntry!.IsStale(), activity, memoryEntry!.Metadata);
 
 			return memoryEntry;
 		}
@@ -509,7 +509,7 @@ public partial class FusionCache
 					_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): using memory entry (expired)", CacheName, InstanceId, operationId, key);
 
 				// EVENT
-				_events.OnHit(operationId, key, true, activity);
+				_events.OnHit(operationId, key, true, activity, memoryEntry.Metadata);
 
 				return memoryEntry;
 			}
@@ -549,7 +549,7 @@ public partial class FusionCache
 			}
 
 			// EVENT
-			_events.OnHit(operationId, key, distributedEntry!.IsStale(), activity);
+			_events.OnHit(operationId, key, distributedEntry!.IsStale(), activity, memoryEntry.Metadata);
 
 			return memoryEntry;
 		}
@@ -573,7 +573,7 @@ public partial class FusionCache
 				}
 
 				// EVENT
-				_events.OnHit(operationId, key, true, activity);
+				_events.OnHit(operationId, key, true, activity, memoryEntry.Metadata);
 
 				return memoryEntry;
 			}
@@ -585,7 +585,7 @@ public partial class FusionCache
 					_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): using memory entry (expired)", CacheName, InstanceId, operationId, key);
 
 				// EVENT
-				_events.OnHit(operationId, key, true, activity);
+				_events.OnHit(operationId, key, true, activity, memoryEntry.Metadata);
 
 				return memoryEntry;
 			}
@@ -740,7 +740,7 @@ public partial class FusionCache
 			}
 
 			// EVENT
-			_events.OnSet(operationId, key);
+			_events.OnSet(operationId, key, entry.Metadata);
 		}
 		catch (Exception exc)
 		{
@@ -1329,7 +1329,7 @@ public partial class FusionCache
 					_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): memory entry updated from distributed", CacheName, InstanceId, operationId, key);
 
 				// EVENT
-				_events.Memory.OnSet(operationId, key);
+				_events.Memory.OnSet(operationId, key, memoryEntry.Metadata);
 
 				return (false, false, true);
 			}

--- a/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Async.cs
@@ -131,7 +131,7 @@ internal partial class DistributedCacheAccessor
 				await _cache.SetAsync(MaybeProcessCacheKey(key), data, distributedOptions, ct).ConfigureAwait(false);
 
 				// EVENT
-				_events.OnSet(operationId, key);
+				_events.OnSet(operationId, key, distributedEntry.Metadata);
 			},
 			"setting entry in distributed" + isBackground.ToString(" (background)"),
 			options,
@@ -236,7 +236,7 @@ internal partial class DistributedCacheAccessor
 			// EVENT
 			if (entry is not null)
 			{
-				_events.OnHit(operationId, key, isValid == false, activity);
+				_events.OnHit(operationId, key, isValid == false, activity, entry.Metadata);
 			}
 			else
 			{

--- a/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Sync.cs
@@ -124,7 +124,7 @@ internal partial class DistributedCacheAccessor
 				_cache.Set(MaybeProcessCacheKey(key), data, distributedOptions);
 
 				// EVENT
-				_events.OnSet(operationId, key);
+				_events.OnSet(operationId, key, entry.Metadata);
 			},
 			"setting entry in distributed" + isBackground.ToString(" (background)"),
 			options,
@@ -220,7 +220,7 @@ internal partial class DistributedCacheAccessor
 			// EVENT
 			if (entry is not null)
 			{
-				_events.OnHit(operationId, key, isValid == false, activity);
+				_events.OnHit(operationId, key, isValid == false, activity, entry.Metadata);
 			}
 			else
 			{

--- a/src/ZiggyCreatures.FusionCache/Internals/Memory/MemoryCacheAccessor.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Memory/MemoryCacheAccessor.cs
@@ -82,7 +82,7 @@ internal sealed class MemoryCacheAccessor
 			}
 
 			// EVENT
-			_events.OnSet(operationId, key);
+			_events.OnSet(operationId, key, entry.Metadata);
 		}
 		catch (Exception exc)
 		{
@@ -107,7 +107,7 @@ internal sealed class MemoryCacheAccessor
 			// EVENT
 			if (entry is not null)
 			{
-				_events.OnHit(operationId, key, entry.IsLogicallyExpired(), activity);
+				_events.OnHit(operationId, key, entry.IsLogicallyExpired(), activity, entry.Metadata);
 			}
 			else
 			{
@@ -164,7 +164,7 @@ internal sealed class MemoryCacheAccessor
 			// EVENT
 			if (entry is not null)
 			{
-				_events.OnHit(operationId, key, isValid == false, activity);
+				_events.OnHit(operationId, key, isValid == false, activity, entry.Metadata);
 			}
 			else
 			{
@@ -244,7 +244,7 @@ internal sealed class MemoryCacheAccessor
 			}
 
 			// EVENT
-			_events.OnExpire(operationId, key);
+			_events.OnExpire(operationId, key, entry.Metadata);
 
 			return true;
 		}

--- a/tests/ZiggyCreatures.FusionCache.Tests/EventsTests_Async.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/EventsTests_Async.cs
@@ -26,7 +26,7 @@ public partial class EventsTests
 
 		EventHandler<FusionCacheEntryEventArgs> onMiss = (s, e) => stats.RecordAction(EntryActionKind.Miss);
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 		EventHandler<FusionCacheEntryEventArgs> onRemove = (s, e) => stats.RecordAction(EntryActionKind.Remove);
 		EventHandler<FusionCacheEntryEventArgs> onFailSafeActivate = (s, e) => stats.RecordAction(EntryActionKind.FailSafeActivate);
 		EventHandler<FusionCacheEntryEventArgs> onFactoryError = (s, e) => stats.RecordAction(EntryActionKind.FactoryError);
@@ -94,14 +94,14 @@ public partial class EventsTests
 		cache.Events.FactoryError -= onFactoryError;
 		cache.Events.FactorySuccess -= onFactorySuccess;
 
-		Assert.Equal(4, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(2, stats.Data[EntryActionKind.HitNormal]);
-		Assert.Equal(2, stats.Data[EntryActionKind.HitStale]);
-		Assert.Equal(2, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(2, stats.Data[EntryActionKind.Remove]);
-		Assert.Equal(2, stats.Data[EntryActionKind.FailSafeActivate]);
-		Assert.Equal(2, stats.Data[EntryActionKind.FactoryError]);
-		Assert.Equal(1, stats.Data[EntryActionKind.FactorySuccess]);
+		Assert.Equal(4, stats[EntryActionKind.Miss]);
+		Assert.Equal(2, stats[EntryActionKind.HitNormal]);
+		Assert.Equal(2, stats[EntryActionKind.HitStale]);
+		Assert.Equal(2, stats[EntryActionKind.Set]);
+		Assert.Equal(2, stats[EntryActionKind.Remove]);
+		Assert.Equal(2, stats[EntryActionKind.FailSafeActivate]);
+		Assert.Equal(2, stats[EntryActionKind.FactoryError]);
+		Assert.Equal(1, stats[EntryActionKind.FactorySuccess]);
 	}
 
 	[Fact]
@@ -121,7 +121,7 @@ public partial class EventsTests
 
 		EventHandler<FusionCacheEntryEventArgs> onMiss = (s, e) => stats.RecordAction(EntryActionKind.Miss);
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 		EventHandler<FusionCacheEntryEventArgs> onRemove = (s, e) => stats.RecordAction(EntryActionKind.Remove);
 		EventHandler<FusionCacheEntryEventArgs> onFailSafeActivate = (s, e) => stats.RecordAction(EntryActionKind.FailSafeActivate);
 
@@ -147,9 +147,9 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(2, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(2, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(4, stats.Data.Values.Sum());
+		Assert.Equal(2, stats[EntryActionKind.Miss]);
+		Assert.Equal(2, stats[EntryActionKind.Set]);
+		Assert.Equal(4, stats.Total);
 	}
 
 	[Fact]
@@ -169,7 +169,7 @@ public partial class EventsTests
 
 		EventHandler<FusionCacheEntryEventArgs> onMiss = (s, e) => stats.RecordAction(EntryActionKind.Miss);
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 		EventHandler<FusionCacheEntryEventArgs> onRemove = (s, e) => stats.RecordAction(EntryActionKind.Remove);
 		EventHandler<FusionCacheEntryEventArgs> onFailSafeActivate = (s, e) => stats.RecordAction(EntryActionKind.FailSafeActivate);
 
@@ -197,10 +197,10 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(0, stats.Data[EntryActionKind.HitStale]);
-		Assert.Equal(1, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(1, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(2, stats.Data.Values.Sum());
+		Assert.Equal(0, stats[EntryActionKind.HitStale]);
+		Assert.Equal(1, stats[EntryActionKind.Miss]);
+		Assert.Equal(1, stats[EntryActionKind.Set]);
+		Assert.Equal(2, stats.Total);
 	}
 
 	[Fact]
@@ -241,8 +241,8 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(1, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(1, stats.Data.Values.Sum());
+		Assert.Equal(1, stats[EntryActionKind.Miss]);
+		Assert.Equal(1, stats.Total);
 	}
 
 	[Fact]
@@ -289,8 +289,8 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(1, stats.Data[EntryActionKind.HitStale]);
-		Assert.Equal(1, stats.Data.Values.Sum());
+		Assert.Equal(1, stats[EntryActionKind.HitStale]);
+		Assert.Equal(1, stats.Total);
 	}
 
 	[Fact]
@@ -337,8 +337,8 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(1, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(1, stats.Data.Values.Sum());
+		Assert.Equal(1, stats[EntryActionKind.Miss]);
+		Assert.Equal(1, stats.Total);
 	}
 
 	[Fact]
@@ -358,7 +358,7 @@ public partial class EventsTests
 
 		EventHandler<FusionCacheEntryEventArgs> onMiss = (s, e) => stats.RecordAction(EntryActionKind.Miss);
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 
 		// SETUP HANDLERS
 		cache.Events.Memory.Miss += onMiss;
@@ -374,9 +374,9 @@ public partial class EventsTests
 		cache.Events.Memory.Hit -= onHit;
 		cache.Events.Memory.Set -= onSet;
 
-		Assert.Equal(2, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(1, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(3, stats.Data.Values.Sum());
+		Assert.Equal(2, stats[EntryActionKind.Miss]);
+		Assert.Equal(1, stats[EntryActionKind.Set]);
+		Assert.Equal(3, stats.Total);
 	}
 
 	[Fact]
@@ -431,10 +431,10 @@ public partial class EventsTests
 		cache3.Events.Backplane.MessagePublished -= onMessagePublished3;
 		cache3.Events.Backplane.MessageReceived -= onMessageReceived3;
 
-		Assert.Equal(1, stats2.Data[EntryActionKind.BackplaneMessagePublished]);
-		Assert.Equal(2, stats2.Data[EntryActionKind.BackplaneMessageReceived]);
-		Assert.Equal(0, stats3.Data[EntryActionKind.BackplaneMessagePublished]);
-		Assert.Equal(3, stats3.Data[EntryActionKind.BackplaneMessageReceived]);
+		Assert.Equal(1, stats2[EntryActionKind.BackplaneMessagePublished]);
+		Assert.Equal(2, stats2[EntryActionKind.BackplaneMessageReceived]);
+		Assert.Equal(0, stats3[EntryActionKind.BackplaneMessagePublished]);
+		Assert.Equal(3, stats3[EntryActionKind.BackplaneMessageReceived]);
 	}
 
 	[Fact]
@@ -446,7 +446,7 @@ public partial class EventsTests
 		using var cache = new FusionCache(new FusionCacheOptions() { EnableSyncEventHandlersExecution = true });
 
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 		EventHandler<FusionCacheEntryEventArgs> onFailSafeActivate = (s, e) => stats.RecordAction(EntryActionKind.FailSafeActivate);
 
 		// SETUP HANDLERS
@@ -474,9 +474,9 @@ public partial class EventsTests
 		Assert.Equal(21, secondValue);
 		Assert.Equal(21, thirdValue);
 		Assert.Equal(21, fourthValue);
-		Assert.Equal(1, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(1, stats.Data[EntryActionKind.HitNormal]);
-		Assert.Equal(2, stats.Data[EntryActionKind.HitStale]);
-		Assert.Equal(1, stats.Data[EntryActionKind.FailSafeActivate]);
+		Assert.Equal(1, stats[EntryActionKind.Set]);
+		Assert.Equal(1, stats[EntryActionKind.HitNormal]);
+		Assert.Equal(2, stats[EntryActionKind.HitStale]);
+		Assert.Equal(1, stats[EntryActionKind.FailSafeActivate]);
 	}
 }

--- a/tests/ZiggyCreatures.FusionCache.Tests/EventsTests_Sync.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/EventsTests_Sync.cs
@@ -26,7 +26,7 @@ public partial class EventsTests
 
 		EventHandler<FusionCacheEntryEventArgs> onMiss = (s, e) => stats.RecordAction(EntryActionKind.Miss);
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 		EventHandler<FusionCacheEntryEventArgs> onRemove = (s, e) => stats.RecordAction(EntryActionKind.Remove);
 		EventHandler<FusionCacheEntryEventArgs> onFailSafeActivate = (s, e) => stats.RecordAction(EntryActionKind.FailSafeActivate);
 		EventHandler<FusionCacheEntryEventArgs> onFactoryError = (s, e) => stats.RecordAction(EntryActionKind.FactoryError);
@@ -94,14 +94,14 @@ public partial class EventsTests
 		cache.Events.FactoryError -= onFactoryError;
 		cache.Events.FactorySuccess -= onFactorySuccess;
 
-		Assert.Equal(4, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(2, stats.Data[EntryActionKind.HitNormal]);
-		Assert.Equal(2, stats.Data[EntryActionKind.HitStale]);
-		Assert.Equal(2, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(2, stats.Data[EntryActionKind.Remove]);
-		Assert.Equal(2, stats.Data[EntryActionKind.FailSafeActivate]);
-		Assert.Equal(2, stats.Data[EntryActionKind.FactoryError]);
-		Assert.Equal(1, stats.Data[EntryActionKind.FactorySuccess]);
+		Assert.Equal(4, stats[EntryActionKind.Miss]);
+		Assert.Equal(2, stats[EntryActionKind.HitNormal]);
+		Assert.Equal(2, stats[EntryActionKind.HitStale]);
+		Assert.Equal(2, stats[EntryActionKind.Set]);
+		Assert.Equal(2, stats[EntryActionKind.Remove]);
+		Assert.Equal(2, stats[EntryActionKind.FailSafeActivate]);
+		Assert.Equal(2, stats[EntryActionKind.FactoryError]);
+		Assert.Equal(1, stats[EntryActionKind.FactorySuccess]);
 	}
 
 	[Fact]
@@ -121,7 +121,7 @@ public partial class EventsTests
 
 		EventHandler<FusionCacheEntryEventArgs> onMiss = (s, e) => stats.RecordAction(EntryActionKind.Miss);
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 		EventHandler<FusionCacheEntryEventArgs> onRemove = (s, e) => stats.RecordAction(EntryActionKind.Remove);
 		EventHandler<FusionCacheEntryEventArgs> onFailSafeActivate = (s, e) => stats.RecordAction(EntryActionKind.FailSafeActivate);
 
@@ -147,9 +147,9 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(2, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(2, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(4, stats.Data.Values.Sum());
+		Assert.Equal(2, stats[EntryActionKind.Miss]);
+		Assert.Equal(2, stats[EntryActionKind.Set]);
+		Assert.Equal(4, stats.Total);
 	}
 
 	[Fact]
@@ -169,7 +169,7 @@ public partial class EventsTests
 
 		EventHandler<FusionCacheEntryEventArgs> onMiss = (s, e) => stats.RecordAction(EntryActionKind.Miss);
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 		EventHandler<FusionCacheEntryEventArgs> onRemove = (s, e) => stats.RecordAction(EntryActionKind.Remove);
 		EventHandler<FusionCacheEntryEventArgs> onFailSafeActivate = (s, e) => stats.RecordAction(EntryActionKind.FailSafeActivate);
 
@@ -197,10 +197,10 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(0, stats.Data[EntryActionKind.HitStale]);
-		Assert.Equal(1, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(1, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(2, stats.Data.Values.Sum());
+		Assert.Equal(0, stats[EntryActionKind.HitStale]);
+		Assert.Equal(1, stats[EntryActionKind.Miss]);
+		Assert.Equal(1, stats[EntryActionKind.Set]);
+		Assert.Equal(2, stats.Total);
 	}
 
 	[Fact]
@@ -241,8 +241,8 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(1, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(1, stats.Data.Values.Sum());
+		Assert.Equal(1, stats[EntryActionKind.Miss]);
+		Assert.Equal(1, stats.Total);
 	}
 
 	[Fact]
@@ -289,8 +289,8 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(1, stats.Data[EntryActionKind.HitStale]);
-		Assert.Equal(1, stats.Data.Values.Sum());
+		Assert.Equal(1, stats[EntryActionKind.HitStale]);
+		Assert.Equal(1, stats.Total);
 	}
 
 	[Fact]
@@ -337,8 +337,8 @@ public partial class EventsTests
 		cache.Events.Remove -= onRemove;
 		cache.Events.FailSafeActivate -= onFailSafeActivate;
 
-		Assert.Equal(1, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(1, stats.Data.Values.Sum());
+		Assert.Equal(1, stats[EntryActionKind.Miss]);
+		Assert.Equal(1, stats.Total);
 	}
 
 	[Fact]
@@ -358,7 +358,7 @@ public partial class EventsTests
 
 		EventHandler<FusionCacheEntryEventArgs> onMiss = (s, e) => stats.RecordAction(EntryActionKind.Miss);
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 
 		// SETUP HANDLERS
 		cache.Events.Memory.Miss += onMiss;
@@ -374,9 +374,9 @@ public partial class EventsTests
 		cache.Events.Memory.Hit -= onHit;
 		cache.Events.Memory.Set -= onSet;
 
-		Assert.Equal(2, stats.Data[EntryActionKind.Miss]);
-		Assert.Equal(1, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(3, stats.Data.Values.Sum());
+		Assert.Equal(2, stats[EntryActionKind.Miss]);
+		Assert.Equal(1, stats[EntryActionKind.Set]);
+		Assert.Equal(3, stats.Total);
 	}
 
 	[Fact]
@@ -431,10 +431,10 @@ public partial class EventsTests
 		cache3.Events.Backplane.MessagePublished -= onMessagePublished3;
 		cache3.Events.Backplane.MessageReceived -= onMessageReceived3;
 
-		Assert.Equal(1, stats2.Data[EntryActionKind.BackplaneMessagePublished]);
-		Assert.Equal(2, stats2.Data[EntryActionKind.BackplaneMessageReceived]);
-		Assert.Equal(0, stats3.Data[EntryActionKind.BackplaneMessagePublished]);
-		Assert.Equal(3, stats3.Data[EntryActionKind.BackplaneMessageReceived]);
+		Assert.Equal(1, stats2[EntryActionKind.BackplaneMessagePublished]);
+		Assert.Equal(2, stats2[EntryActionKind.BackplaneMessageReceived]);
+		Assert.Equal(0, stats3[EntryActionKind.BackplaneMessagePublished]);
+		Assert.Equal(3, stats3[EntryActionKind.BackplaneMessageReceived]);
 	}
 
 	[Fact]
@@ -446,7 +446,7 @@ public partial class EventsTests
 		using var cache = new FusionCache(new FusionCacheOptions() { EnableSyncEventHandlersExecution = true });
 
 		EventHandler<FusionCacheEntryHitEventArgs> onHit = (s, e) => stats.RecordAction(e.IsStale ? EntryActionKind.HitStale : EntryActionKind.HitNormal);
-		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordAction(EntryActionKind.Set);
+		EventHandler<FusionCacheEntryEventArgs> onSet = (s, e) => stats.RecordActionIf(EntryActionKind.Set, e is FusionCacheEntrySetEventArgs);
 		EventHandler<FusionCacheEntryEventArgs> onFailSafeActivate = (s, e) => stats.RecordAction(EntryActionKind.FailSafeActivate);
 
 		// SETUP HANDLERS
@@ -474,9 +474,9 @@ public partial class EventsTests
 		Assert.Equal(21, secondValue);
 		Assert.Equal(21, thirdValue);
 		Assert.Equal(21, fourthValue);
-		Assert.Equal(1, stats.Data[EntryActionKind.Set]);
-		Assert.Equal(1, stats.Data[EntryActionKind.HitNormal]);
-		Assert.Equal(2, stats.Data[EntryActionKind.HitStale]);
-		Assert.Equal(1, stats.Data[EntryActionKind.FailSafeActivate]);
+		Assert.Equal(1, stats[EntryActionKind.Set]);
+		Assert.Equal(1, stats[EntryActionKind.HitNormal]);
+		Assert.Equal(2, stats[EntryActionKind.HitStale]);
+		Assert.Equal(1, stats[EntryActionKind.FailSafeActivate]);
 	}
 }

--- a/tests/ZiggyCreatures.FusionCache.Tests/Stuff/EntryActionsStats.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/Stuff/EntryActionsStats.cs
@@ -13,9 +13,17 @@ public class EntryActionsStats
 		}
 	}
 
+	public int this[EntryActionKind kind] => Data[kind];
+	public int Total => Data.Values.Sum();
 	public ConcurrentDictionary<EntryActionKind, int> Data { get; }
 	public void RecordAction(EntryActionKind kind)
 	{
 		Data.AddOrUpdate(kind, 1, (_, x) => x + 1);
+	}
+
+	public void RecordActionIf(EntryActionKind kind, bool condition)
+	{
+		if (condition)
+			RecordAction(kind);
 	}
 }


### PR DESCRIPTION
I've updated the events to include the cache entry metadata when possible.  
The purpose is to let event subscribers have access to the metadata to take further actions based on attributes such as `LastModifiedTimestamp` or `EagerExpirationTimestamp`.  
To avoid breaking changes on the public API, I've kept the event delegates as they are and added new constructors to the event args classes where metadata were added.
New classes have been created when the events relied on the base event args. However, these are not part of the delegates as that would have resulted in breaking changes. It is still possible for the consumers to cast the received args to access the metadata property.