### PR TITLE
Implement clear all cache feature by * tag

### DIFF
--- a/src/ZiggyCreatures.FusionCache/MicrosoftHybridCache/FusionHybridCache.cs
+++ b/src/ZiggyCreatures.FusionCache/MicrosoftHybridCache/FusionHybridCache.cs
@@ -14,6 +14,7 @@ public sealed class FusionHybridCache
 	: HybridCache
 {
 	private const FusionCacheEntryOptions? NoEntryOptions = null;
+	private const string ClearAllTag = "*";
 
 	private readonly IFusionCache _fusionCache;
 
@@ -99,6 +100,11 @@ public sealed class FusionHybridCache
 	/// <inheritdoc/>
 	public override ValueTask RemoveByTagAsync(string tag, CancellationToken cancellationToken = default)
 	{
+		if (tag == ClearAllTag)
+		{
+			return _fusionCache.ClearAsync(true, NoEntryOptions, cancellationToken);
+		}
+		
 		return _fusionCache.RemoveByTagAsync(tag, NoEntryOptions, cancellationToken);
 	}
 


### PR DESCRIPTION
Implement clear all cache feature by * tag as described in Microsoft documentation for HybridCache.

Added functionality to clear all cache entries when the * tag is used.

Closes #600