### PR TITLE
refactor: use monotonic clock for circuit breaker and auto-recovery

### DIFF
--- a/src/ZiggyCreatures.FusionCache/Internals/AutoRecovery/AutoRecoveryService.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/AutoRecovery/AutoRecoveryService.cs
@@ -20,7 +20,9 @@ internal sealed class AutoRecoveryService
 	private readonly TimeSpan _delay;
 	private static readonly TimeSpan _minDelay = TimeSpan.FromMilliseconds(10);
 	private CancellationTokenSource? _cts;
-	private long _barrierTicks = 0;
+
+	private const long NoBarrierAnchor = long.MinValue;
+	private long _barrierTimestamp = NoBarrierAnchor;
 
 	public AutoRecoveryService(FusionCache cache, FusionCacheOptions options, ILogger<FusionCache>? logger)
 	{
@@ -239,8 +241,8 @@ internal sealed class AutoRecoveryService
 		if (_queue.IsEmpty)
 			return false;
 
-		var newBarrier = DateTimeOffset.UtcNow.Ticks + _delay.Ticks;
-		var oldBarrier = Interlocked.Exchange(ref _barrierTicks, newBarrier);
+		var newBarrier = Stopwatch.GetTimestamp();
+		var oldBarrier = Interlocked.Exchange(ref _barrierTimestamp, newBarrier);
 
 		if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 			_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId}): auto-recovery barrier set from {OldAutoRecoveryBarrier} to {NewAutoRecoveryBarrier}", _cache.CacheName, _cache.InstanceId, operationId, oldBarrier, newBarrier);
@@ -253,12 +255,12 @@ internal sealed class AutoRecoveryService
 
 	internal bool IsBehindBarrier()
 	{
-		var barrierTicks = Interlocked.Read(ref _barrierTicks);
+		var anchor = Interlocked.Read(ref _barrierTimestamp);
 
-		if (DateTimeOffset.UtcNow.Ticks < barrierTicks)
-			return true;
+		if (anchor == NoBarrierAnchor)
+			return false;
 
-		return false;
+		return StopwatchPolyfill.GetElapsedTime(anchor) < _delay;
 	}
 
 	internal async ValueTask<bool> TryProcessQueueAsync(string operationId, CancellationToken token)
@@ -599,24 +601,27 @@ internal sealed class AutoRecoveryService
 			{
 				var operationId = FusionCacheInternalUtils.MaybeGenerateOperationId(_logger);
 				var delay = _delay;
-				var nowTicks = DateTimeOffset.UtcNow.Ticks;
-				var barrierTicks = Interlocked.Read(ref _barrierTicks);
-				if (nowTicks < barrierTicks)
+				var anchor = Interlocked.Read(ref _barrierTimestamp);
+				if (anchor != NoBarrierAnchor)
 				{
-					// SET THE NEW DELAY TO REACH THE BARRIER (+ A MICROSCOPIC EXTRA)
-					var oldDelay = delay;
-					var newDelayTicks = barrierTicks - nowTicks + 1_000;
-					delay = TimeSpan.FromTicks(newDelayTicks);
-
-					// CHECK IF THE NEW DELAY IS BELOW A SAFETY LIMIT
-					if (delay < _minDelay)
+					var elapsed = StopwatchPolyfill.GetElapsedTime(anchor);
+					if (elapsed < _delay)
 					{
-						delay = _minDelay;
-						newDelayTicks = delay.Ticks;
-					}
+						// SET THE NEW DELAY TO REACH THE BARRIER (+ A MICROSCOPIC EXTRA)
+						var oldDelay = delay;
+						var newDelayTicks = (_delay - elapsed).Ticks + 1_000;
+						delay = TimeSpan.FromTicks(newDelayTicks);
 
-					if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
-						_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId}): instead of the standard auto-recovery delay of {AutoRecoveryNormalDelay} the new delay is {AutoRecoveryNewDelay} ({AutoRecoveryNewDelayMs} ms, {AutoRecoveryNewDelayTicks} ticks)", _cache.CacheName, _cache.InstanceId, operationId, oldDelay, delay, delay.TotalMilliseconds, newDelayTicks);
+						// CHECK IF THE NEW DELAY IS BELOW A SAFETY LIMIT
+						if (delay < _minDelay)
+						{
+							delay = _minDelay;
+							newDelayTicks = delay.Ticks;
+						}
+
+						if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
+							_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId}): instead of the standard auto-recovery delay of {AutoRecoveryNormalDelay} the new delay is {AutoRecoveryNewDelay} ({AutoRecoveryNewDelayMs} ms, {AutoRecoveryNewDelayTicks} ticks)", _cache.CacheName, _cache.InstanceId, operationId, oldDelay, delay, delay.TotalMilliseconds, newDelayTicks);
+					}
 				}
 
 				if (_queue.IsEmpty == false)

--- a/src/ZiggyCreatures.FusionCache/Internals/AutoRecovery/AutoRecoveryService.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/AutoRecovery/AutoRecoveryService.cs
@@ -20,7 +20,9 @@ internal sealed class AutoRecoveryService
 	private readonly TimeSpan _delay;
 	private static readonly TimeSpan _minDelay = TimeSpan.FromMilliseconds(10);
 	private CancellationTokenSource? _cts;
-	private long _barrierTicks = 0;
+
+	private const long NoBarrierAnchor = long.MinValue;
+	private long _barrierTimestamp = NoBarrierAnchor;
 
 	public AutoRecoveryService(FusionCache cache, FusionCacheOptions options, ILogger<FusionCache>? logger)
 	{
@@ -239,8 +241,8 @@ internal sealed class AutoRecoveryService
 		if (_queue.IsEmpty)
 			return false;
 
-		var newBarrier = DateTimeOffset.UtcNow.Ticks + _delay.Ticks;
-		var oldBarrier = Interlocked.Exchange(ref _barrierTicks, newBarrier);
+		var newBarrier = Stopwatch.GetTimestamp();
+		var oldBarrier = Interlocked.Exchange(ref _barrierTimestamp, newBarrier);
 
 		if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 			_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId}): auto-recovery barrier set from {OldAutoRecoveryBarrier} to {NewAutoRecoveryBarrier}", _cache.CacheName, _cache.InstanceId, operationId, oldBarrier, newBarrier);
@@ -251,14 +253,30 @@ internal sealed class AutoRecoveryService
 		return true;
 	}
 
+	/// <summary>
+	/// Gets the time still missing to reach the barrier, if a barrier is set and has not been reached yet.
+	/// </summary>
+	private bool TryGetBarrierRemaining(out TimeSpan remaining)
+	{
+		remaining = TimeSpan.Zero;
+
+		var anchor = Interlocked.Read(ref _barrierTimestamp);
+
+		if (anchor == NoBarrierAnchor)
+			return false;
+
+		var elapsed = StopwatchPolyfill.GetElapsedTime(anchor);
+
+		if (elapsed >= _delay)
+			return false;
+
+		remaining = _delay - elapsed;
+		return true;
+	}
+
 	internal bool IsBehindBarrier()
 	{
-		var barrierTicks = Interlocked.Read(ref _barrierTicks);
-
-		if (DateTimeOffset.UtcNow.Ticks < barrierTicks)
-			return true;
-
-		return false;
+		return TryGetBarrierRemaining(out _);
 	}
 
 	internal async ValueTask<bool> TryProcessQueueAsync(string operationId, CancellationToken token)
@@ -599,13 +617,11 @@ internal sealed class AutoRecoveryService
 			{
 				var operationId = FusionCacheInternalUtils.MaybeGenerateOperationId(_logger);
 				var delay = _delay;
-				var nowTicks = DateTimeOffset.UtcNow.Ticks;
-				var barrierTicks = Interlocked.Read(ref _barrierTicks);
-				if (nowTicks < barrierTicks)
+				if (TryGetBarrierRemaining(out var barrierRemaining))
 				{
 					// SET THE NEW DELAY TO REACH THE BARRIER (+ A MICROSCOPIC EXTRA)
 					var oldDelay = delay;
-					var newDelayTicks = barrierTicks - nowTicks + 1_000;
+					var newDelayTicks = barrierRemaining.Ticks + 1_000;
 					delay = TimeSpan.FromTicks(newDelayTicks);
 
 					// CHECK IF THE NEW DELAY IS BELOW A SAFETY LIMIT

--- a/src/ZiggyCreatures.FusionCache/Internals/SimpleCircuitBreaker.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/SimpleCircuitBreaker.cs
@@ -1,4 +1,6 @@
-﻿namespace ZiggyCreatures.Caching.Fusion.Internals;
+using System.Diagnostics;
+
+namespace ZiggyCreatures.Caching.Fusion.Internals;
 
 /// <summary>
 /// A simple, reusable circuit-breaker.
@@ -8,9 +10,10 @@ internal sealed class SimpleCircuitBreaker
 	private const int CircuitStateClosed = 0;
 	private const int CircuitStateOpen = 1;
 
+	private const long NoAnchor = long.MinValue;
+
 	private int _circuitState;
-	private long _gatewayTicks;
-	private readonly long _breakDurationTicks;
+	private long _gatewayTimestamp = NoAnchor;
 
 	/// <summary>
 	/// Creates a new <see cref="SimpleCircuitBreaker"/> instance.
@@ -19,8 +22,6 @@ internal sealed class SimpleCircuitBreaker
 	public SimpleCircuitBreaker(TimeSpan breakDuration)
 	{
 		BreakDuration = breakDuration;
-		_breakDurationTicks = BreakDuration.Ticks;
-		_gatewayTicks = DateTimeOffset.MinValue.Ticks;
 	}
 
 	/// <summary>
@@ -36,13 +37,13 @@ internal sealed class SimpleCircuitBreaker
 	public bool TryOpen(out bool isStateChanged)
 	{
 		// NO CIRCUIT-BREAKER DURATION
-		if (_breakDurationTicks == 0)
+		if (BreakDuration == TimeSpan.Zero)
 		{
 			isStateChanged = false;
 			return false;
 		}
 
-		Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.UtcNow.Ticks + _breakDurationTicks);
+		Interlocked.Exchange(ref _gatewayTimestamp, Stopwatch.GetTimestamp());
 
 		// DETECT CIRCUIT STATE CHANGE
 		var oldCircuitState = Interlocked.Exchange(ref _circuitState, CircuitStateOpen);
@@ -57,7 +58,7 @@ internal sealed class SimpleCircuitBreaker
 	/// <param name="isStateChanged">Indicates if the circuit has been closed with this operation.</param>
 	public void Close(out bool isStateChanged)
 	{
-		Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.MinValue.Ticks);
+		Interlocked.Exchange(ref _gatewayTimestamp, NoAnchor);
 
 		// DETECT CIRCUIT STATE CHANGE
 		var oldCircuitState = Interlocked.Exchange(ref _circuitState, CircuitStateClosed);
@@ -75,13 +76,13 @@ internal sealed class SimpleCircuitBreaker
 		isStateChanged = false;
 
 		// NO CIRCUIT-BREAKER DURATION
-		if (_breakDurationTicks == 0)
+		if (BreakDuration == TimeSpan.Zero)
 			return true;
 
-		long gatewayTicksLocal = Interlocked.Read(ref _gatewayTicks);
+		var anchor = Interlocked.Read(ref _gatewayTimestamp);
 
 		// NOT ENOUGH TIME IS PASSED
-		if (DateTimeOffset.UtcNow.Ticks < gatewayTicksLocal)
+		if (anchor != NoAnchor && StopwatchPolyfill.GetElapsedTime(anchor) < BreakDuration)
 			return false;
 
 		if (_circuitState == CircuitStateOpen)

--- a/src/ZiggyCreatures.FusionCache/Internals/SimpleCircuitBreaker.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/SimpleCircuitBreaker.cs
@@ -1,4 +1,6 @@
-﻿namespace ZiggyCreatures.Caching.Fusion.Internals;
+﻿using System.Diagnostics;
+
+namespace ZiggyCreatures.Caching.Fusion.Internals;
 
 /// <summary>
 /// A simple, reusable circuit-breaker.
@@ -8,9 +10,10 @@ internal sealed class SimpleCircuitBreaker
 	private const int CircuitStateClosed = 0;
 	private const int CircuitStateOpen = 1;
 
+	private const long NoAnchor = long.MinValue;
+
 	private int _circuitState;
-	private long _gatewayTicks;
-	private readonly long _breakDurationTicks;
+	private long _gatewayTimestamp = NoAnchor;
 
 	/// <summary>
 	/// Creates a new <see cref="SimpleCircuitBreaker"/> instance.
@@ -19,8 +22,6 @@ internal sealed class SimpleCircuitBreaker
 	public SimpleCircuitBreaker(TimeSpan breakDuration)
 	{
 		BreakDuration = breakDuration;
-		_breakDurationTicks = BreakDuration.Ticks;
-		_gatewayTicks = DateTimeOffset.MinValue.Ticks;
 	}
 
 	/// <summary>
@@ -36,13 +37,13 @@ internal sealed class SimpleCircuitBreaker
 	public bool TryOpen(out bool isStateChanged)
 	{
 		// NO CIRCUIT-BREAKER DURATION
-		if (_breakDurationTicks == 0)
+		if (BreakDuration == TimeSpan.Zero)
 		{
 			isStateChanged = false;
 			return false;
 		}
 
-		Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.UtcNow.Ticks + _breakDurationTicks);
+		Interlocked.Exchange(ref _gatewayTimestamp, Stopwatch.GetTimestamp());
 
 		// DETECT CIRCUIT STATE CHANGE
 		var oldCircuitState = Interlocked.Exchange(ref _circuitState, CircuitStateOpen);
@@ -57,7 +58,7 @@ internal sealed class SimpleCircuitBreaker
 	/// <param name="isStateChanged">Indicates if the circuit has been closed with this operation.</param>
 	public void Close(out bool isStateChanged)
 	{
-		Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.MinValue.Ticks);
+		Interlocked.Exchange(ref _gatewayTimestamp, NoAnchor);
 
 		// DETECT CIRCUIT STATE CHANGE
 		var oldCircuitState = Interlocked.Exchange(ref _circuitState, CircuitStateClosed);
@@ -75,13 +76,13 @@ internal sealed class SimpleCircuitBreaker
 		isStateChanged = false;
 
 		// NO CIRCUIT-BREAKER DURATION
-		if (_breakDurationTicks == 0)
+		if (BreakDuration == TimeSpan.Zero)
 			return true;
 
-		long gatewayTicksLocal = Interlocked.Read(ref _gatewayTicks);
+		var anchor = Interlocked.Read(ref _gatewayTimestamp);
 
 		// NOT ENOUGH TIME IS PASSED
-		if (DateTimeOffset.UtcNow.Ticks < gatewayTicksLocal)
+		if (anchor != NoAnchor && StopwatchPolyfill.GetElapsedTime(anchor) < BreakDuration)
 			return false;
 
 		if (_circuitState == CircuitStateOpen)

--- a/src/ZiggyCreatures.FusionCache/Internals/StopwatchPolyfill.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/StopwatchPolyfill.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace ZiggyCreatures.Caching.Fusion.Internals;
+
+internal static class StopwatchPolyfill
+{
+#if !NET7_0_OR_GREATER
+	private static readonly double s_tickFrequency = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
+#endif
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static TimeSpan GetElapsedTime(long startingTimestamp)
+	{
+#if NET7_0_OR_GREATER
+		return Stopwatch.GetElapsedTime(startingTimestamp);
+#else
+		return new TimeSpan((long)((Stopwatch.GetTimestamp() - startingTimestamp) * s_tickFrequency));
+#endif
+	}
+}

--- a/src/ZiggyCreatures.FusionCache/Internals/StopwatchPolyfill.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/StopwatchPolyfill.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace ZiggyCreatures.Caching.Fusion.Internals;
+
+internal static class StopwatchPolyfill
+{
+#if !NET7_0_OR_GREATER
+	private static readonly double _tickFrequency = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
+#endif
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static TimeSpan GetElapsedTime(long startingTimestamp)
+	{
+#if NET7_0_OR_GREATER
+		return Stopwatch.GetElapsedTime(startingTimestamp);
+#else
+		return new TimeSpan((long)((Stopwatch.GetTimestamp() - startingTimestamp) * _tickFrequency));
+#endif
+	}
+}

--- a/tests/ZiggyCreatures.FusionCache.Tests/SimpleCircuitBreakerTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/SimpleCircuitBreakerTests.cs
@@ -1,0 +1,139 @@
+using FusionCacheTests.Stuff;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion.Internals;
+
+namespace FusionCacheTests;
+
+public class SimpleCircuitBreakerTests
+{
+	[Fact]
+	public void ZeroBreakDuration_TryOpen_IsNoOp()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.Zero);
+
+		var opened = cb.TryOpen(out var openChanged);
+		var closed = cb.IsClosed(out var closeChanged);
+
+		Assert.False(opened);
+		Assert.False(openChanged);
+		Assert.True(closed);
+		Assert.False(closeChanged);
+	}
+
+	[Fact]
+	public void TryOpen_FirstTime_ReportsStateChange()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+
+		var opened = cb.TryOpen(out var stateChanged);
+
+		Assert.True(opened);
+		Assert.True(stateChanged);
+	}
+
+	[Fact]
+	public void TryOpen_WhileAlreadyOpen_ReportsNoStateChange()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+		cb.TryOpen(out _);
+
+		var opened = cb.TryOpen(out var stateChanged);
+
+		Assert.True(opened);
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public void IsClosed_BeforeFirstOpen_ReturnsTrue()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+
+		var closed = cb.IsClosed(out var stateChanged);
+
+		Assert.True(closed);
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public void IsClosed_WithinBreakDuration_ReturnsFalse()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(10));
+		cb.TryOpen(out _);
+
+		var closed = cb.IsClosed(out var stateChanged);
+
+		Assert.False(closed);
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public async Task IsClosed_AfterBreakDurationElapses_ReturnsTrueAndReportsStateChange()
+	{
+		var breakDuration = TimeSpan.FromSeconds(1);
+		var cb = new SimpleCircuitBreaker(breakDuration);
+		cb.TryOpen(out _);
+
+		await Task.Delay(breakDuration.PlusASecond(), TestContext.Current.CancellationToken);
+
+		var closed = cb.IsClosed(out var stateChanged);
+
+		Assert.True(closed);
+		Assert.True(stateChanged);
+	}
+
+	[Fact]
+	public async Task IsClosed_AfterBreakDurationElapses_SubsequentCallReportsNoStateChange()
+	{
+		var breakDuration = TimeSpan.FromSeconds(1);
+		var cb = new SimpleCircuitBreaker(breakDuration);
+		cb.TryOpen(out _);
+		await Task.Delay(breakDuration.PlusASecond(), TestContext.Current.CancellationToken);
+		cb.IsClosed(out _);
+
+		var closed = cb.IsClosed(out var stateChanged);
+
+		Assert.True(closed);
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public void Close_AfterTryOpen_ReportsStateChange()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+		cb.TryOpen(out _);
+
+		cb.Close(out var stateChanged);
+
+		Assert.True(stateChanged);
+		Assert.True(cb.IsClosed(out _));
+	}
+
+	[Fact]
+	public void Close_WhenAlreadyClosed_ReportsNoStateChange()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+
+		cb.Close(out var stateChanged);
+
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public async Task TryOpen_ResetsBreakWindow()
+	{
+		var breakDuration = TimeSpan.FromSeconds(2);
+		var cb = new SimpleCircuitBreaker(breakDuration);
+		cb.TryOpen(out _);
+
+		await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+		// re-open: the window restarts from "now"
+		cb.TryOpen(out _);
+
+		// ~1s into the new 2s window — the original window would already be expired without the reset
+		await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+		Assert.False(cb.IsClosed(out _));
+
+		await Task.Delay(breakDuration.PlusASecond(), TestContext.Current.CancellationToken);
+		Assert.True(cb.IsClosed(out _));
+	}
+}

--- a/tests/ZiggyCreatures.FusionCache.Tests/SimpleCircuitBreakerTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/SimpleCircuitBreakerTests.cs
@@ -1,0 +1,139 @@
+﻿using FusionCacheTests.Stuff;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion.Internals;
+
+namespace FusionCacheTests;
+
+public class SimpleCircuitBreakerTests
+{
+	[Fact]
+	public void ZeroBreakDuration_TryOpen_IsNoOp()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.Zero);
+
+		var opened = cb.TryOpen(out var openChanged);
+		var closed = cb.IsClosed(out var closeChanged);
+
+		Assert.False(opened);
+		Assert.False(openChanged);
+		Assert.True(closed);
+		Assert.False(closeChanged);
+	}
+
+	[Fact]
+	public void TryOpen_FirstTime_ReportsStateChange()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+
+		var opened = cb.TryOpen(out var stateChanged);
+
+		Assert.True(opened);
+		Assert.True(stateChanged);
+	}
+
+	[Fact]
+	public void TryOpen_WhileAlreadyOpen_ReportsNoStateChange()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+		cb.TryOpen(out _);
+
+		var opened = cb.TryOpen(out var stateChanged);
+
+		Assert.True(opened);
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public void IsClosed_BeforeFirstOpen_ReturnsTrue()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+
+		var closed = cb.IsClosed(out var stateChanged);
+
+		Assert.True(closed);
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public void IsClosed_WithinBreakDuration_ReturnsFalse()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(10));
+		cb.TryOpen(out _);
+
+		var closed = cb.IsClosed(out var stateChanged);
+
+		Assert.False(closed);
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public async Task IsClosed_AfterBreakDurationElapses_ReturnsTrueAndReportsStateChange()
+	{
+		var breakDuration = TimeSpan.FromSeconds(1);
+		var cb = new SimpleCircuitBreaker(breakDuration);
+		cb.TryOpen(out _);
+
+		await Task.Delay(breakDuration.PlusASecond(), TestContext.Current.CancellationToken);
+
+		var closed = cb.IsClosed(out var stateChanged);
+
+		Assert.True(closed);
+		Assert.True(stateChanged);
+	}
+
+	[Fact]
+	public async Task IsClosed_AfterBreakDurationElapses_SubsequentCallReportsNoStateChange()
+	{
+		var breakDuration = TimeSpan.FromSeconds(1);
+		var cb = new SimpleCircuitBreaker(breakDuration);
+		cb.TryOpen(out _);
+		await Task.Delay(breakDuration.PlusASecond(), TestContext.Current.CancellationToken);
+		cb.IsClosed(out _);
+
+		var closed = cb.IsClosed(out var stateChanged);
+
+		Assert.True(closed);
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public void Close_AfterTryOpen_ReportsStateChange()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+		cb.TryOpen(out _);
+
+		cb.Close(out var stateChanged);
+
+		Assert.True(stateChanged);
+		Assert.True(cb.IsClosed(out _));
+	}
+
+	[Fact]
+	public void Close_WhenAlreadyClosed_ReportsNoStateChange()
+	{
+		var cb = new SimpleCircuitBreaker(TimeSpan.FromSeconds(1));
+
+		cb.Close(out var stateChanged);
+
+		Assert.False(stateChanged);
+	}
+
+	[Fact]
+	public async Task TryOpen_ResetsBreakWindow()
+	{
+		var breakDuration = TimeSpan.FromSeconds(2);
+		var cb = new SimpleCircuitBreaker(breakDuration);
+		cb.TryOpen(out _);
+
+		await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+		// re-open: the window restarts from "now"
+		cb.TryOpen(out _);
+
+		// ~1s into the new 2s window — the original window would already be expired without the reset
+		await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+		Assert.False(cb.IsClosed(out _));
+
+		await Task.Delay(breakDuration.PlusASecond(), TestContext.Current.CancellationToken);
+		Assert.True(cb.IsClosed(out _));
+	}
+}


### PR DESCRIPTION
Switch SimpleCircuitBreaker and AutoRecoveryService from `DateTimeOffset.UtcNow` based deadlines to `Stopwatch.GetElapsedTime`. Both are in-process deadline gates; their elapsed-time math should be unaffected by wall-clock adjustments (NTP correction, manual clock change).

Same change was recently added by me to dotnet/runtime#127303. I am flagging this as a refactor, since in-process deadline gates should be measured monotonically, even though using DateTime.UtcNow in this use-case will probably never lead to problems in practice. This mirrors open-telemetry/opentelemetry-dotnet#7193 (sweep) and open-telemetry/opentelemetry-dotnet#7253 (in-process freshness check). 

Wall-clock usage is preserved for serialized timestamps (LogicalExpirationTimestamp, BackplaneMessage.Timestamp, AutoRecoveryItem expiration) since those cross process boundaries.